### PR TITLE
Update CI and PR workflow configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
         mode: lint
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
-        additional-planemo-options: --biocontainers --skip version_bumped -s stdio,tests,output,inputs,help,general,command,citations,tool_xsd,xml_order,tool_urls,shed_metadata,urls,readme,shed_yaml,repository_dependencies,tool_dependencies_actions,tool_dependencies_sha256sum,tool_dependencies_xsd,expansion
+        additional-planemo-options: --skip version_bumped
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
         echo 'Using ${{ steps.discover.outputs.chunk-count }} chunks (${{ steps.discover.outputs.chunk-list }})'
 
   lint:
-    name: Check for missing containers
+    name: Lint tool-list
     needs: setup
     if: ${{ needs.setup.outputs.repository-list != '' || needs.setup.outputs.tool-list != '' }}
     runs-on: ubuntu-latest
@@ -101,6 +101,7 @@ jobs:
       id: lint
       with:
         mode: lint
+        fail-level: warn
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
         additional-planemo-options: --skip version_bumped

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ env:
   GALAXY_FORK: galaxyproject
   GALAXY_BRANCH: release_24.1
   MAX_CHUNKS: 4
-  MAX_FILE_SIZE: 88M
+  MAX_FILE_SIZE: 2M
 concurrency:
   # Group runs by PR, but keep runs on the default branch separate
   # because we do not want to cancel ToolShed uploads


### PR DESCRIPTION
Simplified Planemo options in the CI workflow by removing extra flags and only skipping 'version_bumped'. Reduced MAX_FILE_SIZE from 88M to 2M in the PR workflow to enforce stricter file size limits.