### PR TITLE
Set lint fail-level to error in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
       id: lint
       with:
         mode: lint
-        fail-level: warn
+        fail-level: error
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
         additional-planemo-options: --skip version_bumped


### PR DESCRIPTION
Changed the lint job's fail-level from 'warn' to 'error' in the CI workflow