### PR TITLE
Enable markdown report in CI coverage step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,6 +201,7 @@ jobs:
       with:
         mode: combine
         html-report: true
+        markdown-report: true
     - uses: actions/upload-artifact@v4
       with:
         name: 'All tool test results'


### PR DESCRIPTION
Adds the 'markdown-report: true' option to the coverage reporting step in the CI workflow to generate a markdown report alongside the existing HTML report.