### PR TITLE
Fix augmentation argument parsing

### DIFF
--- a/tools/imagelearner/image_learner_cli.py
+++ b/tools/imagelearner/image_learner_cli.py
@@ -1240,6 +1240,8 @@ def aug_parse(aug_string: str):
     aug_list = []
     for tok in aug_string.split(","):
         key = tok.strip()
+        if not key:
+            continue
         if key not in mapping:
             valid = ", ".join(mapping.keys())
             raise ValueError(f"Unknown augmentation '{key}'. Valid choices: {valid}")


### PR DESCRIPTION
When no augmentations are selected (or `--augmentation ""` is passed), skip parsing
empty tokens instead of raising a ValueError.

- Only call aug_parse if args.augmentation is truthy
- Or have aug_parse ignore blank entries