### PR TITLE
Add plotly to Docker image dependencies

### DIFF
--- a/tools/galaxy-ludwig/Docker/galaxy_ludwig_ray_gpu/Dockerfile
+++ b/tools/galaxy-ludwig/Docker/galaxy_ludwig_ray_gpu/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get -y update && apt-get install -y unzip && \
 RUN pip install -U pip
     
 RUN pip install --no-cache-dir 'git+https://github.com/goeckslab/model-unpickler.git' && \
-    pip install --no-cache-dir 'git+https://github.com/goeckslab/smart-report.git@17df590f3ceb065add099f37b4874c85bd275014'
+    pip install --no-cache-dir 'git+https://github.com/goeckslab/smart-report.git@17df590f3ceb065add099f37b4874c85bd275014' && \
+    pip install --no-cache-dir plotly
 
 RUN useradd -m -s /bin/bash nonrootuser
 


### PR DESCRIPTION
The Dockerfile now installs the plotly Python package to support visualization features in the galaxy_ludwig_ray_gpu environment.