### PR TITLE
Handle SHAP explainer exceptions gracefully

### DIFF
--- a/tools/tabularlearner/feature_importance.py
+++ b/tools/tabularlearner/feature_importance.py
@@ -136,10 +136,15 @@ class FeatureImportanceAnalyzer:
 
         predict_fn = model.predict_proba if hasattr(model, "predict_proba") else model.predict
 
-        explainer = shap.Explainer(predict_fn, bg)
-        self.shap_model_name = explainer.__class__.__name__
+        try:
+            explainer = shap.Explainer(predict_fn, bg)
+            self.shap_model_name = explainer.__class__.__name__
 
-        shap_values = explainer(X_data)
+            shap_values = explainer(X_data)
+        except Exception as e:
+            LOG.error(f"SHAP computation failed: {e}")
+            self.shap_model_name = None
+            return
 
         output_names = getattr(shap_values, "output_names", None)
         if output_names is None and hasattr(model, "classes_"):

--- a/tools/tabularlearner/pycaret_macros.xml
+++ b/tools/tabularlearner/pycaret_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TABULAR_LEARNER_VERSION@">0.1.0</token>
+    <token name="@TABULAR_LEARNER_VERSION@">0.1.0.1</token>
     <token name="@PYCARET_VERSION@">3.3.2</token>
     <token name="@SUFFIX@">1</token>
     <token name="@PYCARET_PREDICT_VERSION@">@PYCARET_VERSION@+@SUFFIX@</token>


### PR DESCRIPTION
Wraps SHAP explainer initialization and computation in a try-except block to log errors and prevent crashes if SHAP fails. Sets shap_model_name to None and returns early on exception.