### PR TITLE
fix tsv input parsing

### DIFF
--- a/tools/imagelearner/image_learner.xml
+++ b/tools/imagelearner/image_learner.xml
@@ -394,12 +394,12 @@
     </outputs>
     <tests>
         <test expect_num_outputs="3">
-            <param name="input_csv" value="mnist_subset.csv" ftype="csv" />
-            <param name="image_zip" value="mnist_subset.zip" ftype="zip" />
-            <param name="model_name" value="resnet18" />
-            <param name="augmentation" value="random_horizontal_flip,random_vertical_flip,random_rotate" />
-            <param name="task_selection|task" value="classification" />
-            <param name="task_selection|validation_metric_multiclass" value="accuracy" />
+            <param name="data_configuration|input_csv" value="mnist_subset.csv" ftype="csv" />
+            <param name="data_configuration|image_zip" value="mnist_subset.zip" ftype="zip" />
+            <param name="model_hyperparameter_configuration|model_name" value="resnet18" />
+            <param name="model_hyperparameter_configuration|augmentation" value="random_horizontal_flip,random_vertical_flip,random_rotate" />
+            <param name="model_hyperparameter_configuration|task_selection|task" value="classification" />
+            <param name="model_hyperparameter_configuration|task_selection|validation_metric_multiclass" value="accuracy" />
             <output name="output_report">
                 <assert_contents>
                     <has_text text="Config and Overall Performance Summary" />
@@ -407,13 +407,18 @@
                     <has_text text="Test Results" />
                 </assert_contents>
             </output>
-            <output name="output_artifacts_zip" ftype="zip" />
+            <output name="output_artifacts_zip" ftype="zip">
+                <assert_contents>
+                    <has_archive_member path="experiment_run/predictions.csv" />
+                    <has_archive_member path="experiment_run/model/.*" negate="true" />
+                </assert_contents>
+            </output>
 
         </test>
         <test expect_num_outputs="3">
-            <param name="input_csv" value="utkface_labels.csv" ftype="csv" />
-            <param name="image_zip" value="age_regression.zip" ftype="zip" />
-            <param name="model_name" value="resnet18" />
+            <param name="data_configuration|input_csv" value="utkface_labels.csv" ftype="csv" />
+            <param name="data_configuration|image_zip" value="age_regression.zip" ftype="zip" />
+            <param name="model_hyperparameter_configuration|model_name" value="resnet18" />
             <output name="output_report">
                 <assert_contents>
                     <has_text text="Config and Overall Performance Summary" />
@@ -421,12 +426,17 @@
                     <has_text text="Test Results" />
                 </assert_contents>
             </output>
-            <output name="output_artifacts_zip" ftype="zip" />
+            <output name="output_artifacts_zip" ftype="zip">
+                <assert_contents>
+                    <has_archive_member path="experiment_run/predictions.csv" />
+                    <has_archive_member path="experiment_run/model/.*" negate="true" />
+                </assert_contents>
+            </output>
         </test>
         <test expect_num_outputs="3">
-            <param name="input_csv" value="mnist_subset.csv" ftype="csv" />
-            <param name="image_zip" value="mnist_subset.zip" ftype="zip" />
-            <param name="model_name" value="caformer_s18" />
+            <param name="data_configuration|input_csv" value="mnist_subset.csv" ftype="csv" />
+            <param name="data_configuration|image_zip" value="mnist_subset.zip" ftype="zip" />
+            <param name="model_hyperparameter_configuration|model_name" value="caformer_s18" />
             <output name="output_report">
                 <assert_contents>
                     <has_text text="Config and Overall Performance Summary" />
@@ -434,14 +444,19 @@
                     <has_text text="Test Results" />
                 </assert_contents>
             </output>
-            <output name="output_artifacts_zip" ftype="zip" />
+            <output name="output_artifacts_zip" ftype="zip">
+                <assert_contents>
+                    <has_archive_member path="experiment_run/predictions.csv" />
+                    <has_archive_member path="experiment_run/model/.*" negate="true" />
+                </assert_contents>
+            </output>
 
         </test>
         <test expect_num_outputs="3">
-            <param name="input_csv" value="mnist_subset.csv" ftype="csv" />
-            <param name="image_zip" value="mnist_subset.zip" ftype="zip" />
-            <param name="model_name" value="randformer_s12" />
-            <param name="epochs" value="5" />
+            <param name="data_configuration|input_csv" value="mnist_subset.csv" ftype="csv" />
+            <param name="data_configuration|image_zip" value="mnist_subset.zip" ftype="zip" />
+            <param name="model_hyperparameter_configuration|model_name" value="randformer_s12" />
+            <param name="customize_defaults_section|epochs" value="5" />
             <output name="output_report">
                 <assert_contents>
                     <has_text text="Test Performance Summary" />
@@ -449,7 +464,12 @@
                     <has_text text="Test Results" />
                 </assert_contents>
             </output>
-            <output name="output_artifacts_zip" ftype="zip" />
+            <output name="output_artifacts_zip" ftype="zip">
+                <assert_contents>
+                    <has_archive_member path="experiment_run/predictions.csv" />
+                    <has_archive_member path="experiment_run/model/.*" negate="true" />
+                </assert_contents>
+            </output>
 
         </test>
         <!-- Test 7: MetaFormer with 384x384 input - verifies model correctly handles non-224x224 dimensions -->
@@ -502,12 +522,12 @@
             <output name="output_artifacts_zip" ftype="zip" />
         </test> -->
         <test expect_num_outputs="3">
-            <param name="input_csv" value="mnist_subset_binary.csv" ftype="csv" />
-            <param name="image_zip" value="mnist_subset.zip" ftype="zip" />
-            <param name="model_name" value="resnet18" />
-            <param name="threshold" value="0.6" />
-            <param name="task_selection|task" value="classification" />
-            <param name="task_selection|validation_metric_multiclass" value="accuracy" />
+            <param name="data_configuration|input_csv" value="mnist_subset_binary.csv" ftype="csv" />
+            <param name="data_configuration|image_zip" value="mnist_subset.zip" ftype="zip" />
+            <param name="model_hyperparameter_configuration|model_name" value="resnet18" />
+            <param name="customize_defaults_section|threshold" value="0.6" />
+            <param name="model_hyperparameter_configuration|task_selection|task" value="classification" />
+            <param name="model_hyperparameter_configuration|task_selection|validation_metric_multiclass" value="accuracy" />
             <output name="output_report">
                 <assert_contents>
                     <has_text text="Config and Overall Performance Summary" />
@@ -517,7 +537,12 @@
                     <has_text text="0.60" />
                 </assert_contents>
             </output>
-            <output name="output_artifacts_zip" ftype="zip" />
+            <output name="output_artifacts_zip" ftype="zip">
+                <assert_contents>
+                    <has_archive_member path="experiment_run/predictions.csv" />
+                    <has_archive_member path="experiment_run/model/.*" negate="true" />
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help>

--- a/tools/imagelearner/image_learner.xml
+++ b/tools/imagelearner/image_learner.xml
@@ -389,7 +389,7 @@
     </inputs>
     <outputs>
         <data format="ludwig_model" name="output_model" label="${tool.name} trained model on ${on_string}" hidden="true" />
-        <data format="html" name="output_report" from_work_dir="image_classification_results_report.html" label="${tool.name} report on ${on_string}" />
+        <data format="html" name="output_report" from_work_dir="image_classification_results_report.html" label="${tool.name} analysis report on ${on_string}" />
         <data format="zip" name="output_artifacts_zip" label="${tool.name} predictions and artifacts on ${on_string}" hidden="true" />
     </outputs>
     <tests>

--- a/tools/multimodallearner/multimodal_learner.xml
+++ b/tools/multimodallearner/multimodal_learner.xml
@@ -38,9 +38,9 @@
 #end if
 
 set -e;
-ln -sf '$input_csv' 'train_input.csv';
+ln -sf '$input_csv' 'train_input.tabular';
 #if $test_dataset_conditional.has_test_dataset == "yes"
-ln -sf '$test_dataset_conditional.input_test' 'test_input.csv';
+ln -sf '$test_dataset_conditional.input_test' 'test_input.tabular';
 #end if
 
 #set $TORCH_HOME = "./torch_cache"
@@ -52,9 +52,9 @@ export HUGGINGFACE_HUB_CACHE="$HUGGINGFACE_HUB_CACHE" &&
 mkdir -p "$TORCH_HOME" "$HUGGINGFACE_HUB_CACHE" &&
 
   python '$__tool_directory__/multimodal_learner.py'
-  --input_csv_train 'train_input.csv'
+  --input_csv_train 'train_input.tabular'
   #if $test_dataset_conditional.has_test_dataset == "yes"
-  --input_csv_test 'test_input.csv'
+  --input_csv_test 'test_input.tabular'
   #end if
   --target_column '$target_column'
   #if $sample_id_selector.use_sample_id == "yes"

--- a/tools/multimodallearner/utils.py
+++ b/tools/multimodallearner/utils.py
@@ -1,3 +1,4 @@
+import csv
 import errno
 import json
 import logging
@@ -128,10 +129,33 @@ def enable_deterministic_mode(seed: Optional[int] = None):
 def load_file(path: str) -> pd.DataFrame:
     if not path:
         return None
+
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"Dataset not found: {path}")
-    return pd.read_csv(path, sep=None, engine="python")
+
+    suffix = path.suffix.lower()
+    if suffix == ".tsv":
+        LOG.info("Loading tabular dataset as TSV: %s", path)
+        return pd.read_csv(path, sep="\t")
+    if suffix == ".csv":
+        LOG.info("Loading tabular dataset as CSV: %s", path)
+        return pd.read_csv(path, sep=",")
+
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        sample = handle.read(8192)
+
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",\t;|")
+        delimiter = dialect.delimiter
+        LOG.info("Detected delimiter %r for tabular dataset: %s", delimiter, path)
+        return pd.read_csv(path, sep=delimiter)
+    except Exception:
+        LOG.warning(
+            "Could not infer delimiter for %s from extension/sample; falling back to pandas autodetection.",
+            path,
+        )
+        return pd.read_csv(path, sep=None, engine="python")
 
 
 def _normalize_path_value(val: object) -> Optional[str]:


### PR DESCRIPTION
# This PR improves tabular input handling in the Multimodal Learner so CSV and TSV datasets are both accepted reliably in Galaxy and parsed correctly at runtime.

## What Changed

Kept Galaxy tool inputs explicitly accepting both csv and tsv for training and optional test datasets.
Updated the Python dataset loader to parse files more intentionally:
.csv files are loaded with comma separation
.tsv files are loaded with tab separation
extension-less or neutral temporary paths fall back to delimiter sniffing and then Pandas autodetection
Replaced hard-coded temporary filenames like train_input.csv / test_input.csv with neutral names (train_input.tabular, test_input.tabular) in the tool wrapper.

## Why

The Galaxy form already advertised CSV/TSV support, but the runtime path depended on generic delimiter autodetection and used .csv-named temporary files. That made TSV support less explicit and more fragile than it should be.

These changes make the behavior clearer and more robust, especially when Galaxy stages datasets through symlinks or temporary filenames that do not preserve the original extension.

## Impact

Standard CSV uploads continue to work.
Standard TSV uploads are now handled explicitly and more safely.
Neutral or extension-less staged inputs still work through delimiter detection.
No user-facing workflow changes are required.
Notes

### This change is designed to be Galaxy-compatible and defensive for normal tabular inputs with headers. Extremely malformed or ambiguous delimited files may still depend on fallback parsing behavior.