### PR TITLE
Fix/plot label

### DIFF
--- a/tools/imagelearner/ludwig_backend.py
+++ b/tools/imagelearner/ludwig_backend.py
@@ -1878,7 +1878,15 @@ class LudwigDirectBackend:
             # Multi-class transparency plots from test stats (replace ROC/PR for multi-class)
             if output_type == "category" and test_stats_path.exists():
                 try:
-                    multi_curves = build_multiclass_metric_plots(str(test_stats_path))
+                    multi_curves = build_multiclass_metric_plots(
+                        str(test_stats_path),
+                        metadata_csv_path=str(label_metadata_path)
+                        if label_metadata_path and label_metadata_path.exists()
+                        else None,
+                        train_set_metadata_path=str(train_set_metadata_path)
+                        if train_set_metadata_path.exists()
+                        else None,
+                    )
                     tab3_content = append_plot_blocks(tab3_content, multi_curves)
                     if multi_curves:
                         logger.info("Added multi-class per-class metric plots to test tab")

--- a/tools/imagelearner/plotly_plots.py
+++ b/tools/imagelearner/plotly_plots.py
@@ -170,29 +170,52 @@ def _resolve_confusion_labels(
     return [str(label) for label in labels[:n_classes]]
 
 
+def _class_index(raw_label) -> Optional[int]:
+    """Return a class index for integer-like labels, otherwise None."""
+    if isinstance(raw_label, bool):
+        return None
+    if isinstance(raw_label, int):
+        return raw_label
+    if isinstance(raw_label, float):
+        return int(raw_label) if raw_label.is_integer() else None
+
+    raw_str = str(raw_label).strip()
+    if not raw_str:
+        return None
+    try:
+        idx_val = float(raw_str)
+    except Exception:
+        return None
+    if idx_val.is_integer():
+        return int(idx_val)
+    return None
+
+
 def _resolve_display_labels(raw_labels: List, friendly_labels: Optional[List[str]]) -> List[str]:
     """Map encoded class ids like 0/1 back to friendly labels when available."""
     if not friendly_labels:
         return [str(label) for label in raw_labels]
 
-    friendly_lookup = {str(label) for label in friendly_labels}
+    friendly_labels = [str(label) for label in friendly_labels]
+    raw_indices = [_class_index(raw_label) for raw_label in raw_labels]
+    if (
+        raw_indices
+        and all(idx is not None for idx in raw_indices)
+        and set(raw_indices) == set(range(len(raw_indices)))
+        and max(raw_indices) < len(friendly_labels)
+    ):
+        return [friendly_labels[idx] for idx in raw_indices]
+
+    friendly_lookup = set(friendly_labels)
     display_labels: List[str] = []
-    for raw_label in raw_labels:
+    for raw_label, idx in zip(raw_labels, raw_indices):
         raw_str = str(raw_label)
         if raw_str in friendly_lookup:
             display_labels.append(raw_str)
             continue
 
-        idx = None
-        try:
-            idx_val = float(raw_str)
-            if idx_val.is_integer():
-                idx = int(idx_val)
-        except Exception:
-            idx = None
-
         if idx is not None and 0 <= idx < len(friendly_labels):
-            display_labels.append(str(friendly_labels[idx]))
+            display_labels.append(friendly_labels[idx])
         else:
             display_labels.append(raw_str)
 

--- a/tools/imagelearner/plotly_plots.py
+++ b/tools/imagelearner/plotly_plots.py
@@ -170,6 +170,35 @@ def _resolve_confusion_labels(
     return [str(label) for label in labels[:n_classes]]
 
 
+def _resolve_display_labels(raw_labels: List, friendly_labels: Optional[List[str]]) -> List[str]:
+    """Map encoded class ids like 0/1 back to friendly labels when available."""
+    if not friendly_labels:
+        return [str(label) for label in raw_labels]
+
+    friendly_lookup = {str(label) for label in friendly_labels}
+    display_labels: List[str] = []
+    for raw_label in raw_labels:
+        raw_str = str(raw_label)
+        if raw_str in friendly_lookup:
+            display_labels.append(raw_str)
+            continue
+
+        idx = None
+        try:
+            idx_val = float(raw_str)
+            if idx_val.is_integer():
+                idx = int(idx_val)
+        except Exception:
+            idx = None
+
+        if idx is not None and 0 <= idx < len(friendly_labels):
+            display_labels.append(str(friendly_labels[idx]))
+        else:
+            display_labels.append(raw_str)
+
+    return display_labels
+
+
 def build_classification_plots(
     test_stats_path: str,
     training_stats_path: Optional[str] = None,
@@ -287,6 +316,7 @@ def build_classification_plots(
     pcs = label_stats.get("per_class_stats", {})
     if pcs:
         classes = list(pcs.keys())
+        display_classes = _resolve_display_labels(classes, labels)
         metrics = [
             "precision",
             "recall",
@@ -309,7 +339,7 @@ def build_classification_plots(
             go.Heatmap(
                 z=z,
                 x=[m.replace("_", " ") for m in metrics],
-                y=[str(c) for c in classes],
+                y=display_classes,
                 text=txt,
                 texttemplate="%{text}",
                 colorscale="Reds",
@@ -1469,7 +1499,11 @@ def build_multiclass_roc_pr_plots(
     return plots
 
 
-def build_multiclass_metric_plots(test_stats_path: str) -> List[Dict[str, str]]:
+def build_multiclass_metric_plots(
+    test_stats_path: str,
+    metadata_csv_path: Optional[str] = None,
+    train_set_metadata_path: Optional[str] = None,
+) -> List[Dict[str, str]]:
     """Alternative multi-class transparency plots using test_statistics.json per-class stats."""
     ts_path = Path(test_stats_path)
     if not ts_path.exists():
@@ -1487,6 +1521,13 @@ def build_multiclass_metric_plots(test_stats_path: str) -> List[Dict[str, str]]:
     classes = list(pcs.keys())
     if not classes:
         return []
+    friendly_labels = _resolve_confusion_labels(
+        label_stats,
+        len(classes),
+        metadata_csv_path=metadata_csv_path,
+        train_set_metadata_path=train_set_metadata_path,
+    )
+    display_classes = _resolve_display_labels(classes, friendly_labels)
 
     metrics = ["precision", "recall", "f1_score", "specificity", "accuracy"]
     fig_bar = go.Figure()
@@ -1497,7 +1538,7 @@ def build_multiclass_metric_plots(test_stats_path: str) -> List[Dict[str, str]]:
             values.append(v if isinstance(v, (int, float)) else 0)
         fig_bar.add_trace(
             go.Bar(
-                x=classes,
+                x=display_classes,
                 y=values,
                 name=metric.replace("_", " ").title(),
             )

--- a/tools/imagelearner/test_plotly_plots.py
+++ b/tools/imagelearner/test_plotly_plots.py
@@ -1,0 +1,9 @@
+from plotly_plots import _resolve_display_labels
+
+
+def test_resolve_display_labels_decodes_ludwig_indices_before_friendly_lookup():
+    assert _resolve_display_labels(["0", "1"], ["1", "2"]) == ["1", "2"]
+
+
+def test_resolve_display_labels_preserves_original_numeric_labels():
+    assert _resolve_display_labels(["1", "2"], ["1", "2"]) == ["1", "2"]

--- a/tools/tabularlearner/pycaret_classification.py
+++ b/tools/tabularlearner/pycaret_classification.py
@@ -8,6 +8,7 @@ import plotly.graph_objects as go
 from base_model_trainer import BaseModelTrainer
 from dashboard import generate_classifier_explainer_dashboard
 from pycaret.classification import ClassificationExperiment
+from pycaret.utils.generic import get_label_encoder
 from sklearn.metrics import (
     auc,
     confusion_matrix,
@@ -139,17 +140,39 @@ class ClassificationModelTrainer(BaseModelTrainer):
 
         X_test = self.exp.X_test_transformed.copy()
         y_test = self.exp.y_test_transformed
-        explainer = ClassifierExplainer(self.best_model, X_test, y_test)
+        label_encoder = None
+        try:
+            label_encoder = get_label_encoder(self.exp.pipeline)
+        except Exception as exc:
+            LOG.debug("Could not load label encoder for explainer labels: %s", exc)
+        explainer_labels = list(label_encoder.classes_) if label_encoder is not None else None
+        explainer = ClassifierExplainer(
+            self.best_model,
+            X_test,
+            y_test,
+            labels=explainer_labels,
+        )
 
         # a dict to hold the raw Figure objects or callables
         self.explainer_plots: Dict[str, go.Figure] = {}
 
         y_true, y_pred, label_values, y_scores = self._get_test_predictions()
+        y_true_display = self._decode_labels_for_display(y_true)
+        y_pred_display = self._decode_labels_for_display(y_pred)
+        label_values_display = pd.unique(
+            pd.concat(
+                [
+                    pd.Series(y_true_display),
+                    pd.Series(y_pred_display),
+                ],
+                ignore_index=True,
+            )
+        ).tolist()
 
         # — Classification report (Plotly table) —
         try:
             fig_report = self._build_classification_report_fig(
-                y_true, y_pred, label_values
+                y_true_display, y_pred_display, label_values_display
             )
             if fig_report is not None:
                 self.explainer_plots["class_report"] = fig_report
@@ -158,7 +181,9 @@ class ClassificationModelTrainer(BaseModelTrainer):
 
         # — Confusion matrix with actual labels —
         try:
-            fig_cm = self._build_confusion_matrix_fig(y_true, y_pred, label_values)
+            fig_cm = self._build_confusion_matrix_fig(
+                y_true_display, y_pred_display, label_values_display
+            )
             if fig_cm is not None:
                 self.explainer_plots["confusion_matrix"] = fig_cm
         except Exception as e:
@@ -329,6 +354,43 @@ class ClassificationModelTrainer(BaseModelTrainer):
                 y_scores = None
         label_values = pd.unique(pd.concat([y_true, y_pred], ignore_index=True))
         return y_true, y_pred, label_values.tolist(), y_scores
+
+    def _decode_labels_for_display(self, values):
+        """Map transformed class ids back to the original target labels for plots."""
+        try:
+            label_encoder = get_label_encoder(self.exp.pipeline)
+        except Exception as exc:
+            LOG.debug("Could not load label encoder for display labels: %s", exc)
+            label_encoder = None
+
+        if label_encoder is None:
+            return values
+
+        def _decode_array(arr):
+            arr = np.asarray(arr, dtype=object)
+            flat = arr.reshape(-1)
+            decoded = flat.copy()
+            mask = pd.notna(flat)
+            if not mask.any():
+                return arr
+            try:
+                decoded_vals = label_encoder.inverse_transform(flat[mask])
+            except Exception as exc:
+                LOG.debug("Could not inverse-transform class labels for display: %s", exc)
+                return arr
+            decoded[mask] = decoded_vals
+            return decoded.reshape(arr.shape)
+
+        if isinstance(values, pd.Series):
+            decoded = _decode_array(values.to_numpy())
+            return pd.Series(decoded, index=values.index, name=values.name)
+
+        decoded = _decode_array(values)
+        if isinstance(values, list):
+            return decoded.tolist()
+        if np.isscalar(values):
+            return decoded.reshape(-1)[0]
+        return decoded
 
     def _threshold_suffix(self) -> str:
         """


### PR DESCRIPTION
## Summary
Fix label display in classification evaluation outputs so reports and plots use the original class names instead of internal encoded ids.

## Problem
Some generated classification visualizations were showing encoded labels like 0, 1, 2 rather than the actual target labels from the dataset. The metrics themselves were correct, but the output was harder to interpret and inconsistent with the labels users expect to see.

## This affected:
Image learner multiclass per-class metric plots
Image learner classification report heatmaps
Tabular learner confusion matrix and classification report outputs
Explainer label display in PyCaret classification workflows

## Changes
Added display-label resolution logic for image learner Plotly classification plots.
Passed metadata paths into multiclass metric plot generation so class ids can be mapped back to original labels.
Updated multiclass per-class metric bar plots and classification heatmaps to render friendly labels.
Pulled the PyCaret label encoder in tabular classification flows and used it to decode labels before building reports and confusion matrices.
Passed decoded labels into ClassifierExplainer so explainer outputs use original class names.
User Impact
Users will now see original dataset labels in evaluation outputs instead of internal numeric encodings, making confusion matrices, per-class metrics, and explainer views easier to read and less error-prone.

## Scope
This PR changes label presentation only. It does not change model training, predictions, or underlying metric calculations.