### PR TITLE
Stabilize learner tests and improve multimodal threshold reporting

### DIFF
--- a/tools/imagelearner/html_structure.py
+++ b/tools/imagelearner/html_structure.py
@@ -559,16 +559,16 @@ def json_to_html_table(json_data) -> str:
 def build_tabbed_html(metrics_html: str, train_val_html: str, test_html: str) -> str:
     """
     Build a 3-tab interface:
-      - Config and Overall Performance Summary
-      - Train/Validation Results
-      - Test Results
+      - Experiment Summary
+      - Validation Summary
+      - Test Summary
     Includes a persistent "Help" button that toggles the metrics modal.
     """
     return f"""
 <div class="tabs">
-  <div class="tab active" onclick="showTab('metrics')">Config and Overall Performance Summary</div>
-  <div class="tab" onclick="showTab('trainval')">Training and Validation Results</div>
-  <div class="tab" onclick="showTab('test')">Test Results</div>
+  <div class="tab active" onclick="showTab('metrics')">Experiment Summary</div>
+  <div class="tab" onclick="showTab('trainval')">Validation Summary</div>
+  <div class="tab" onclick="showTab('test')">Test Summary</div>
   <button id="openMetricsHelp" class="help-btn" title="Open metrics help">Help</button>
 </div>
 

--- a/tools/imagelearner/html_structure.py
+++ b/tools/imagelearner/html_structure.py
@@ -231,7 +231,7 @@ def get_html_template():
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>Image Learner Report</title>
+  <title>Image Learner Experiment Report</title>
   <style>
     body {
       font-family: Arial, sans-serif;

--- a/tools/imagelearner/image_learner.xml
+++ b/tools/imagelearner/image_learner.xml
@@ -389,7 +389,7 @@
     </inputs>
     <outputs>
         <data format="ludwig_model" name="output_model" label="${tool.name} trained model on ${on_string}" hidden="true" />
-        <data format="html" name="output_report" from_work_dir="image_classification_results_report.html" label="${tool.name} analysis report on ${on_string}" />
+        <data format="html" name="output_report" from_work_dir="image_classification_results_report.html" label="Image Learner Experiment Report" />
         <data format="zip" name="output_artifacts_zip" label="${tool.name} predictions and artifacts on ${on_string}" hidden="true" />
     </outputs>
     <tests>

--- a/tools/imagelearner/image_learner.xml
+++ b/tools/imagelearner/image_learner.xml
@@ -402,9 +402,9 @@
             <param name="model_hyperparameter_configuration|task_selection|validation_metric_multiclass" value="accuracy" />
             <output name="output_report">
                 <assert_contents>
-                    <has_text text="Config and Overall Performance Summary" />
-                    <has_text text="Training and Validation Results" />
-                    <has_text text="Test Results" />
+                    <has_text text="Experiment Summary" />
+                    <has_text text="Validation Summary" />
+                    <has_text text="Test Summary" />
                 </assert_contents>
             </output>
             <output name="output_artifacts_zip" ftype="zip">
@@ -421,9 +421,9 @@
             <param name="model_hyperparameter_configuration|model_name" value="resnet18" />
             <output name="output_report">
                 <assert_contents>
-                    <has_text text="Config and Overall Performance Summary" />
-                    <has_text text="Training and Validation Results" />
-                    <has_text text="Test Results" />
+                    <has_text text="Experiment Summary" />
+                    <has_text text="Validation Summary" />
+                    <has_text text="Test Summary" />
                 </assert_contents>
             </output>
             <output name="output_artifacts_zip" ftype="zip">
@@ -439,9 +439,9 @@
             <param name="model_hyperparameter_configuration|model_name" value="caformer_s18" />
             <output name="output_report">
                 <assert_contents>
-                    <has_text text="Config and Overall Performance Summary" />
-                    <has_text text="Training and Validation Results" />
-                    <has_text text="Test Results" />
+                    <has_text text="Experiment Summary" />
+                    <has_text text="Validation Summary" />
+                    <has_text text="Test Summary" />
                 </assert_contents>
             </output>
             <output name="output_artifacts_zip" ftype="zip">
@@ -460,8 +460,8 @@
             <output name="output_report">
                 <assert_contents>
                     <has_text text="Test Performance Summary" />
-                    <has_text text="Training and Validation Results" />
-                    <has_text text="Test Results" />
+                    <has_text text="Validation Summary" />
+                    <has_text text="Test Summary" />
                 </assert_contents>
             </output>
             <output name="output_artifacts_zip" ftype="zip">
@@ -480,9 +480,9 @@
             <param name="image_resize" value="384x384" />
             <output name="output_report">
                 <assert_contents>
-                    <has_text text="Config and Overall Performance Summary" />
-                    <has_text text="Training and Validation Results" />
-                    <has_text text="Test Results" />
+                    <has_text text="Experiment Summary" />
+                    <has_text text="Validation Summary" />
+                    <has_text text="Test Summary" />
                 </assert_contents>
             </output>
             <output name="output_artifacts_zip" ftype="zip" />
@@ -497,7 +497,7 @@
                 <assert_contents>
                     <has_text text="Results Summary" />
                     <has_text text="Train/Validation Results" />
-                    <has_text text="Test Results" />
+                    <has_text text="Test Summary" />
                     <has_text text="ROC-AUC Curves" />
                 </assert_contents>
             </output>
@@ -514,7 +514,7 @@
                 <assert_contents>
                     <has_text text="Results Summary" />
                     <has_text text="Train/Validation Results" />
-                    <has_text text="Test Results" />
+                    <has_text text="Test Summary" />
                     <has_text text="ROC-AUC Curves" />
                     <has_text text="Micro-average ROC" />
                 </assert_contents>
@@ -530,9 +530,9 @@
             <param name="model_hyperparameter_configuration|task_selection|validation_metric_multiclass" value="accuracy" />
             <output name="output_report">
                 <assert_contents>
-                    <has_text text="Config and Overall Performance Summary" />
-                    <has_text text="Training and Validation Results" />
-                    <has_text text="Test Results" />
+                    <has_text text="Experiment Summary" />
+                    <has_text text="Validation Summary" />
+                    <has_text text="Test Summary" />
                     <has_text text="Threshold" />
                     <has_text text="0.60" />
                 </assert_contents>

--- a/tools/imagelearner/image_workflow.py
+++ b/tools/imagelearner/image_workflow.py
@@ -472,7 +472,7 @@ class ImageLearnerCLI:
                 self.backend.generate_plots(self.args.output_dir)
                 # Build HTML report (robust to missing metrics)
                 report_file = self.backend.generate_html_report(
-                    "Image Classification Results",
+                    "Image Learner Experiment Report",
                     self.args.output_dir,
                     backend_args,
                     split_info,
@@ -498,7 +498,7 @@ class ImageLearnerCLI:
                     self._create_minimal_outputs(self.args.output_dir, csv_path)
                     # Even in fallback, produce an HTML shell so tests find required text
                     report_file = self.backend.generate_html_report(
-                        "Image Classification Results",
+                        "Image Learner Experiment Report",
                         self.args.output_dir,
                         backend_args,
                         split_info,

--- a/tools/imagelearner/ludwig_backend.py
+++ b/tools/imagelearner/ludwig_backend.py
@@ -1263,7 +1263,7 @@ class LudwigDirectBackend:
     ) -> Path:
         """Assemble an HTML report from visualizations under train_val/ and test/ folders."""
         cwd = Path.cwd()
-        report_name = title.lower().replace(" ", "_") + "_report.html"
+        report_name = "image_classification_results_report.html"
         report_path = cwd / report_name
         output_dir = Path(output_dir)
         output_type = None

--- a/tools/imagelearner/test-data/expected_regression.html
+++ b/tools/imagelearner/test-data/expected_regression.html
@@ -2,7 +2,7 @@
     <html>
     <head>
         <meta charset="UTF-8">
-        <title>Galaxy-Ludwig Report</title>
+        <title>Image Learner Experiment Report</title>
         <style>
           body {
               font-family: Arial, sans-serif;
@@ -67,7 +67,7 @@
     </head>
     <body>
     <div class="container">
-    <h1>Image Classification Results</h1>
+    <h1>Image Learner Experiment Report</h1>
 <style>
   .tabs {
     display: flex;
@@ -273,4 +273,3 @@ document.addEventListener("DOMContentLoaded", function() {
     </div>
     </body>
     </html>
-    

--- a/tools/imagelearner/test-data/expected_regression.html
+++ b/tools/imagelearner/test-data/expected_regression.html
@@ -114,7 +114,7 @@
 <div class="tabs">
   <div class="tab active" onclick="showTab('metrics')">Config &amp; Results Summary</div>
   <div class="tab" onclick="showTab('trainval')">Train/Validation Results</div>
-  <div class="tab" onclick="showTab('test')">Test Results</div>
+  <div class="tab" onclick="showTab('test')">Test Summary</div>
   <!-- always-visible help button -->
   <button id="openMetricsHelp" class="help-btn">Help</button>
 </div>

--- a/tools/imagelearner/test-data/image_classification_results_report_mnist.html
+++ b/tools/imagelearner/test-data/image_classification_results_report_mnist.html
@@ -1,7 +1,7 @@
 
     <html>
     <head>
-        <title>Galaxy-Ludwig Report</title>
+        <title>Image Learner Experiment Report</title>
         <style>
           body {
               font-family: Arial, sans-serif;
@@ -66,7 +66,7 @@
     </head>
     <body>
     <div class="container">
-    <h1>Image Classification Results</h1>
+    <h1>Image Learner Experiment Report</h1>
 <style>
 .tabs {
   display: flex;
@@ -126,4 +126,3 @@ function showTab(id) {
     </div>
     </body>
     </html>
-    

--- a/tools/multimodallearner/feature_help_modal.py
+++ b/tools/multimodallearner/feature_help_modal.py
@@ -10,8 +10,8 @@ def get_metrics_help_modal() -> str:
     <h2>How to read this Multimodal Learner report</h2>
     <div class="metrics-guide">
       <h3>Tabs & layout</h3>
-      <p><strong>Model Metric Summary and Config:</strong> Top-level metrics and the key run settings (target column, backbones, presets).</p>
-      <p><strong>Train and Validation Summary:</strong> Learning curves plus combined ROC/PR/Calibration (binary), and any remaining diagnostics.</p>
+      <p><strong>Experiment Summary:</strong> Top-level metrics and the key run settings (target column, backbones, presets).</p>
+      <p><strong>Validation Summary:</strong> Learning curves plus combined ROC/PR/Calibration (binary), and any remaining diagnostics.</p>
       <p><strong>Test Summary:</strong> Test metrics table followed by the ROC/PR charts with your chosen threshold marked, and the Prediction Confidence histogram.</p>
 
       <h3>Dataset Overview</h3>

--- a/tools/multimodallearner/metrics_logic.py
+++ b/tools/multimodallearner/metrics_logic.py
@@ -486,14 +486,15 @@ def evaluate_all_transparency(
     roc_curves: Dict[str, dict] = {}
     splits = []
 
-    # IMPORTANT: do NOT apply threshold to Train/Val
+    # Use the selected binary decision threshold consistently across all splits.
+    # Probability-dependent metrics such as ROC-AUC and PR-AUC still use raw scores.
     if train_df is not None and len(train_df):
         train_metrics, train_curve = compute_metrics_for_split(
             predictor,
             train_df,
             target_col,
             problem_type,
-            threshold=None,
+            threshold=threshold,
             return_curve=True,
         )
         split_results["Train"] = train_metrics
@@ -506,7 +507,7 @@ def evaluate_all_transparency(
             val_df,
             target_col,
             problem_type,
-            threshold=None,
+            threshold=threshold,
             return_curve=True,
         )
         split_results["Validation"] = val_metrics

--- a/tools/multimodallearner/multimodal_learner.xml
+++ b/tools/multimodallearner/multimodal_learner.xml
@@ -326,7 +326,7 @@ mkdir -p "$TORCH_HOME" "$HUGGINGFACE_HUB_CACHE" &&
   </inputs>
 
   <outputs>
-    <data name="output_html" format="html" label="Multimodal Learner analysis report on data ${on_string}"/>
+    <data name="output_html" format="html" label="Multimodal Learner Experiment Report"/>
     <data name="output_config" format="yaml" label="Multimodal Learner training config on data ${on_string}" hidden="true"/>
     <data name="output_json" format="json" label="Multimodal Learner metric results on data ${on_string}" hidden="true"/>
     <data name="output_model_archive" format="zip" label="Multimodal Learner trained model on data ${on_string}" hidden="true"/>

--- a/tools/multimodallearner/plot_logic.py
+++ b/tools/multimodallearner/plot_logic.py
@@ -1677,6 +1677,7 @@ def assemble_full_html_report(
     tabs = build_tabbed_html(summary_html, train_html, test_full, feature_html, explainer_html=None)
 
     html_out = get_html_template()
+    html_out += "<h1>Multimodal Learner Experiment Report</h1>"
 
     # 🔧 Ensure Plotly JS is available (we render plots with include_plotlyjs=False)
     html_out += '\n<script src="https://cdn.plot.ly/plotly-2.30.0.min.js"></script>\n'

--- a/tools/multimodallearner/plot_logic.py
+++ b/tools/multimodallearner/plot_logic.py
@@ -393,24 +393,52 @@ def generate_threshold_plot(
         hovertemplate="Threshold=%{x:.3f}<br>Queue Rate=%{y:.3f}<extra></extra>"
     ))
 
-    # F1*-optimal threshold marker (dashed vertical line)
-    fig.add_vline(
-        x=t_star,
-        line_width=2,
-        line_dash="dash",
-        line_color="black",
-        annotation_text=f"t* = {t_star:.2f}",
-        annotation_position="top"
+    def _add_threshold_marker(x_value: float, text: str, color: str, dash: str | None, y_pos: float) -> None:
+        x_value = float(np.clip(x_value, 0.0, 1.0))
+        fig.add_shape(
+            type="line",
+            xref="x",
+            yref="paper",
+            x0=x_value,
+            x1=x_value,
+            y0=0,
+            y1=1,
+            line=dict(color=color, width=2, dash=dash or "solid"),
+        )
+        fig.add_annotation(
+            x=x_value,
+            y=y_pos,
+            xref="x",
+            yref="paper",
+            text=text,
+            showarrow=False,
+            xanchor="left" if x_value < 0.8 else "right",
+            yanchor="top",
+            bgcolor="rgba(255,255,255,0.92)",
+            bordercolor=color,
+            borderwidth=1,
+            borderpad=3,
+            font=dict(size=12, color="#24364f"),
+        )
+
+    user_t = float(user_threshold) if user_threshold is not None else None
+    markers_are_close = user_t is not None and abs(float(t_star) - user_t) < 0.04
+    _add_threshold_marker(
+        t_star,
+        f"t* = {t_star:.2f}",
+        "black",
+        "dash",
+        0.98 if markers_are_close else 0.96,
     )
 
     # User threshold (solid red line) if provided
-    if user_threshold is not None:
-        fig.add_vline(
-            x=float(user_threshold),
-            line_width=2,
-            line_color="red",
-            annotation_text=f"threshold = {float(user_threshold):.2f}",
-            annotation_position="top"
+    if user_t is not None:
+        _add_threshold_marker(
+            user_t,
+            f"threshold = {user_t:.2f}",
+            "red",
+            None,
+            0.88 if markers_are_close else 0.98,
         )
 
     fig.update_layout(
@@ -437,7 +465,7 @@ def generate_threshold_plot(
             xanchor="right",
             x=1.0
         ),
-        margin=dict(l=60, r=20, t=40, b=50),
+        margin=dict(l=60, r=20, t=60, b=50),
         plot_bgcolor="white",
         paper_bgcolor="white",
     )

--- a/tools/multimodallearner/report_utils.py
+++ b/tools/multimodallearner/report_utils.py
@@ -972,8 +972,8 @@ def build_tabbed_html(
     """
     tabs = [
         '<div class="tabs">',
-        '<div class="tab active" onclick="showTab(\'summary\')">Model Metric Summary and Config</div>',
-        '<div class="tab" onclick="showTab(\'train\')">Train and Validation Summary</div>',
+        '<div class="tab active" onclick="showTab(\'summary\')">Experiment Summary</div>',
+        '<div class="tab" onclick="showTab(\'train\')">Validation Summary</div>',
         '<div class="tab" onclick="showTab(\'test\')">Test Summary</div>',
     ]
     if explainer_html:

--- a/tools/multimodallearner/report_utils.py
+++ b/tools/multimodallearner/report_utils.py
@@ -137,9 +137,6 @@ def _build_threshold_rows(problem_type: str, metadata: dict) -> List[tuple[str, 
         ("Threshold source", metadata.get("threshold_source") or "Unknown"),
         ("Threshold optimization metric", metric_display),
     ]
-    metric_value = metadata.get("threshold_metric_value")
-    if metric_value is not None:
-        rows.append((f"Validation {metric_display} at threshold", f"{float(metric_value):.3f}"))
     reason = metadata.get("threshold_reason")
     if reason:
         rows.append(("Threshold note", reason))

--- a/tools/multimodallearner/report_utils.py
+++ b/tools/multimodallearner/report_utils.py
@@ -703,7 +703,7 @@ def get_html_template() -> str:
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>Galaxy-Ludwig Report</title>
+  <title>Multimodal Learner Experiment Report</title>
   <style>
     body {
       font-family: Arial, sans-serif;

--- a/tools/multimodallearner/test_metrics_logic.py
+++ b/tools/multimodallearner/test_metrics_logic.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from metrics_logic import optimize_binary_threshold, resolve_threshold_metric
+from metrics_logic import evaluate_all_transparency, optimize_binary_threshold, resolve_threshold_metric
 
 
 class FakeBinaryPredictor:
@@ -15,6 +15,18 @@ class FakeBinaryPredictor:
                 1: self.positive_scores,
             }
         )
+
+
+class FeatureScoreBinaryPredictor:
+    class_labels = [0, 1]
+
+    def predict_proba(self, features):
+        scores = features["feature"].astype(float).reset_index(drop=True)
+        return pd.DataFrame({0: 1.0 - scores, 1: scores})
+
+    def predict(self, features):
+        scores = self.predict_proba(features)[1]
+        return pd.Series((scores >= 0.5).astype(int))
 
 
 def test_resolve_threshold_metric_uses_threshold_sensitive_eval_metric():
@@ -40,3 +52,22 @@ def test_optimize_binary_threshold_uses_validation_probabilities():
     assert result["threshold_metric"] == "f1"
     assert result["threshold_source"] == "Optimized on validation split"
     assert round(result["threshold_metric_value"], 3) == 0.8
+
+
+def test_evaluate_all_transparency_applies_binary_threshold_to_all_splits():
+    df = pd.DataFrame({"feature": [0.1, 0.2, 0.35, 0.4], "label": [0, 0, 1, 1]})
+
+    _, raw_metrics, _ = evaluate_all_transparency(
+        predictor=FeatureScoreBinaryPredictor(),
+        train_df=df,
+        val_df=df,
+        test_df=df,
+        target_col="label",
+        problem_type="binary",
+        threshold=0.3,
+    )
+
+    for split in ["Train", "Validation", "Test"]:
+        assert raw_metrics[split]["Precision"] == 1.0
+        assert raw_metrics[split]["Recall_(Sensitivity/TPR)"] == 1.0
+        assert raw_metrics[split]["F1-Score"] == 1.0

--- a/tools/multimodallearner/test_report_utils.py
+++ b/tools/multimodallearner/test_report_utils.py
@@ -62,4 +62,4 @@ def test_build_threshold_rows_describes_optimized_threshold():
     assert ("Decision threshold (Test)", "0.350") in rows
     assert ("Threshold source", "Optimized on validation split") in rows
     assert ("Threshold optimization metric", "F1") in rows
-    assert ("Validation F1 at threshold", "0.800") in rows
+    assert ("Validation F1 at threshold", "0.800") not in rows

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -201,7 +201,7 @@
     <outputs>
         <data name="model" format="h5" from_work_dir="pycaret_model.h5" label="${tool.name} best model on ${on_string}" hidden="true" />
         <data name="best_model_csv" format="csv" from_work_dir="best_model.csv" label="${tool.name} The parameters of the best model on ${on_string}" hidden="true" />
-        <data name="comparison_result" format="html" from_work_dir="comparison_result.html" label="${tool.name} analysis report on ${on_string}" />
+        <data name="comparison_result" format="html" from_work_dir="comparison_result.html" label="Tabular Learner Experiment Report" />
     </outputs>
     <tests>
         <test>


### PR DESCRIPTION
# Summary

This PR updates learner behavior and tests around model selection and binary threshold handling.

---

## Changes

- Removes the **Validation F1 at threshold** row from the Multimodal Learner Model Configuration table  
- Applies the selected binary decision threshold consistently to **Train**, **Validation**, and **Test** metrics so threshold-dependent metrics like Precision, Recall, and F1 do not remain at default-threshold values for Train/Validation  
- Improves the Multimodal Learner validation threshold plot by:
  - rendering threshold annotations as readable boxed labels  
  - offsetting close markers to avoid overlapping text  