### PR TITLE
remove PR-AUC column from models validation table

### DIFF
--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1374,14 +1374,7 @@ class BaseModelTrainer:
             return ""
 
         split_predictions = self._get_split_predictions_for_report()
-        validation_best_row = None
-        try:
-            if isinstance(self.results, pd.DataFrame) and not self.results.empty:
-                validation_best_row = self.results.iloc[0]
-        except Exception:
-            validation_best_row = None
-
-        if not split_predictions and validation_best_row is None:
+        if not split_predictions:
             return ""
 
         metric_names = [
@@ -1395,17 +1388,6 @@ class BaseModelTrainer:
             "MCC",
         ]
 
-        validation_column_map = {
-            "Accuracy": ["Accuracy"],
-            "ROC-AUC": ["ROC-AUC", "AUC"],
-            "Precision": ["Precision", "Prec.", "Prec"],
-            "Recall": ["Recall"],
-            "F1-Score": ["F1-Score", "F1"],
-            "PR-AUC": ["PR-AUC", "PR-AUC-Weighted", "PRC"],
-            "Specificity": ["Specificity"],
-            "MCC": ["MCC"],
-        }
-
         def _fmt(value):
             if value is None:
                 return "—"
@@ -1418,19 +1400,8 @@ class BaseModelTrainer:
             except Exception:
                 return str(value)
 
-        def _validation_metric(metric_name):
-            if validation_best_row is None:
-                return None
-            cols = validation_column_map.get(metric_name, [])
-            for col in cols:
-                if col in validation_best_row:
-                    try:
-                        return validation_best_row[col]
-                    except Exception:
-                        return None
-            return None
-
         rows = []
+        validation_preds = split_predictions.get("Validation")
         for metric in metric_names:
             row = [metric]
             # Train
@@ -1439,18 +1410,12 @@ class BaseModelTrainer:
             )
             row.append(_fmt(train_val))
 
-            # Validation from the cross-validation summary first row; fallback to computed CV.
-            # PR-AUC is computed from probabilities so it matches the report's PR curve.
-            if metric == "PR-AUC":
-                val_val = self._compute_metric_value(
-                    metric, split_predictions.get("Validation"), "Validation"
-                )
-            else:
-                val_val = _validation_metric(metric)
-                if val_val is None:
-                    val_val = self._compute_metric_value(
-                        metric, split_predictions.get("Validation"), "Validation"
-                    )
+            # Validation is shown only when validation predictions exist. This
+            # avoids mixing selected-model metrics with PyCaret comparison rows
+            # when cross-validation is disabled.
+            val_val = self._compute_metric_value(
+                metric, validation_preds, "Validation"
+            )
             row.append(_fmt(val_val))
 
             # Test
@@ -1470,6 +1435,60 @@ class BaseModelTrainer:
             )
             + "</div>"
         )
+
+    @staticmethod
+    def _prepare_model_comparison_display_df(df, metric_prefix=""):
+        """
+        Prepare PyCaret comparison output for the HTML report.
+
+        This table must remain a direct PyCaret model-comparison table. Do not
+        inject selected-model metrics here; those belong in Best Model
+        Performance, where all split metrics are computed from the same
+        prediction bundles.
+        """
+        display_df = df.copy()
+        display_df.drop(
+            columns=[
+                "TT (Ec)",
+                "TT (Sec)",
+                "PR-AUC",
+                "PR-AUC-Weighted",
+                "PRC",
+            ],
+            errors="ignore",
+            inplace=True,
+        )
+        if metric_prefix:
+            metric_columns = {
+                "Accuracy",
+                "ROC-AUC",
+                "AUC",
+                "Precision",
+                "Prec.",
+                "Prec",
+                "Recall",
+                "F1-Score",
+                "F1",
+                "Kappa",
+                "MCC",
+                "Log Loss",
+                "LogLoss",
+                "MAE",
+                "MSE",
+                "RMSE",
+                "R2",
+                "RMSLE",
+                "MAPE",
+            }
+            display_df.rename(
+                columns={
+                    col: f"{metric_prefix}{col}"
+                    for col in display_df.columns
+                    if col in metric_columns
+                },
+                inplace=True,
+            )
+        return display_df
 
     def _resolve_plot_callable(self, key, fig_or_fn, section):
         """
@@ -1622,8 +1641,14 @@ class BaseModelTrainer:
         # 5) Header
         header = f"<h2>Best Model: {best_model_name}</h2>"
 
-        # — Validation Summary & Configuration —
-        val_df = self.results.copy()
+        validation_enabled = getattr(self, "cross_validation", None) is not False
+        comparison_metric_prefix = "CV " if validation_enabled else "Comparison "
+
+        # — Model Comparison & Configuration —
+        val_df = self._prepare_model_comparison_display_df(
+            self.results,
+            metric_prefix=comparison_metric_prefix,
+        )
         dataset_overview_html = self._build_dataset_overview()
         performance_summary_html = self._build_performance_summary_table()
         # mapping raw plot keys to user-friendly titles
@@ -1642,30 +1667,23 @@ class BaseModelTrainer:
             "residuals": "Residuals Distribution",
             "error": "Prediction Error Distribution",
         }
-        val_df.drop(
-            columns=[
-                "TT (Ec)",
-                "TT (Sec)",
-                "PR-AUC",
-                "PR-AUC-Weighted",
-                "PRC",
-            ],
-            errors="ignore",
-            inplace=True,
+        summary_tab_label = "Model Comparison"
+        summary_heading = (
+            "Cross-Validation Model Comparison Across Candidate Models"
+            if validation_enabled
+            else "Model Comparison Across Candidate Models"
         )
         summary_html = (
-            "<h2>Cross-Validation Validation Summary Across Candidate Models</h2>"
+            f"<h2>{summary_heading}</h2>"
             + '<div class="table-wrapper">'
             + val_df.to_html(index=False, classes="table sortable")
             + "</div>"
         )
 
         if self.tuning_results is not None:
-            tuning_df = self.tuning_results.copy()
-            tuning_df.drop(
-                columns=["TT (Sec)", "PR-AUC", "PR-AUC-Weighted", "PRC"],
-                errors="ignore",
-                inplace=True,
+            tuning_df = self._prepare_model_comparison_display_df(
+                self.tuning_results,
+                metric_prefix=comparison_metric_prefix,
             )
             summary_html += (
                 f"<h2>{best_model_name}: Tuning Summary</h2>"
@@ -1948,6 +1966,7 @@ class BaseModelTrainer:
             feature_html,
             explainer_html=None,
             config_html=config_html,
+            summary_tab_label=summary_tab_label,
         )
         html += get_feature_metrics_help_modal()
         html += get_html_closing()

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -703,10 +703,10 @@ class BaseModelTrainer:
 
     def _build_dataset_overview(self):
         """
-        Build an HTML table showing label counts with labels as rows and splits
-        (Train / Validation / Test) as columns. Each cell shows count and
-        percentage of that split. Returns empty string for regression or when
-        no label data is available.
+        Build an HTML table showing label counts for the data used by the
+        report. When cross-validation is enabled, validation metrics are based
+        on out-of-fold predictions across the training/CV pool, not a single
+        fixed validation split.
         """
         if self.task_type != "classification":
             return ""
@@ -731,7 +731,6 @@ class BaseModelTrainer:
 
         # Prefer original-label PyCaret splits; fall back to transformed labels
         # only when originals are unavailable.
-        X_train = _get_from_config(["X_train_transformed", "X_train"])
         y_train = _get_from_config(["y_train", "y_train_transformed"])
         y_test_cfg = _get_from_config(["y_test", "y_test_transformed"])
 
@@ -739,25 +738,6 @@ class BaseModelTrainer:
             y_train = self.data[self.target]
 
         y_train_series = _safe_series(y_train)
-
-        # Build a cross-validation generator to derive a validation subset size.
-        cv_gen = self._get_cv_generator(y_train_series)
-        y_train_fold = y_train_series
-        y_val_fold = None
-        if cv_gen is not None and y_train_series is not None:
-            try:
-                # Use the first fold to approximate Train/Validation split sizes.
-                splitter = cv_gen.split(
-                    pd.DataFrame(X_train).reset_index(drop=True)
-                    if X_train is not None
-                    else y_train_series,
-                    y_train_series,
-                )
-                train_idx, val_idx = next(iter(splitter))
-                y_train_fold = y_train_series.iloc[train_idx].reset_index(drop=True)
-                y_val_fold = y_train_series.iloc[val_idx].reset_index(drop=True)
-            except Exception as exc:
-                LOG.warning("Could not derive validation split for dataset overview: %s", exc)
 
         # Test labels: prefer external/raw labels, then PyCaret original labels,
         # then transformed labels.
@@ -771,9 +751,10 @@ class BaseModelTrainer:
         else:
             y_test = y_test_cfg
 
+        validation_enabled = getattr(self, "cross_validation", None) is not False
+        train_label = "Training / CV Pool" if validation_enabled else "Train"
         split_map = {
-            "Train": _safe_series(y_train_fold),
-            "Validation": _safe_series(y_val_fold),
+            train_label: _safe_series(y_train_series),
             "Test": _safe_series(y_test),
         }
         split_map = {
@@ -807,7 +788,7 @@ class BaseModelTrainer:
         rows = []
         for label in labels:
             row = ["NaN" if pd.isna(label) else str(label)]
-            for split_name in ["Train", "Validation", "Test"]:
+            for split_name in split_map:
                 cnt, total = _count_for_label(split_map.get(split_name), label)
                 if cnt is None or total is None:
                     cell = "—"
@@ -817,11 +798,18 @@ class BaseModelTrainer:
                 row.append(cell)
             rows.append(row)
 
-        df = pd.DataFrame(rows, columns=["Label", "Train", "Validation", "Test"])
+        df = pd.DataFrame(rows, columns=["Label", *split_map.keys()])
         df.sort_values("Label", inplace=True)
 
+        note = (
+            "<p><em>Validation metrics use out-of-fold predictions across the "
+            "training/CV pool.</em></p>"
+            if validation_enabled
+            else ""
+        )
         return (
             "<h2>Dataset Overview</h2>"
+            + note
             + '<div class="table-wrapper">'
             + df.to_html(
                 index=False,
@@ -1581,15 +1569,20 @@ class BaseModelTrainer:
             elif key in {
                 "Normalize",
                 "Feature Selection",
-                "Cross Validation",
                 "Remove Outliers",
                 "Remove Multicollinearity",
                 "Polynomial Features",
                 "Fix Imbalance",
             }:
                 dv = bool(v)
+            elif key == "Cross Validation":
+                dv = True if v is None else bool(v)
             elif key == "Cross Validation Folds":
-                dv = v if v is not None else "None"
+                cv_enabled = all_params.get("cross_validation")
+                if cv_enabled is False:
+                    dv = "None"
+                else:
+                    dv = v if v is not None else 10
             elif key == "Models":
                 dv = ", ".join(map(str, v)) if isinstance(
                     v, (list, tuple)

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1643,7 +1643,15 @@ class BaseModelTrainer:
             "error": "Prediction Error Distribution",
         }
         val_df.drop(
-            columns=["TT (Ec)", "TT (Sec)"], errors="ignore", inplace=True
+            columns=[
+                "TT (Ec)",
+                "TT (Sec)",
+                "PR-AUC",
+                "PR-AUC-Weighted",
+                "PRC",
+            ],
+            errors="ignore",
+            inplace=True,
         )
         summary_html = (
             "<h2>Cross-Validation Validation Summary Across Candidate Models</h2>"
@@ -1655,7 +1663,9 @@ class BaseModelTrainer:
         if self.tuning_results is not None:
             tuning_df = self.tuning_results.copy()
             tuning_df.drop(
-                columns=["TT (Sec)"], errors="ignore", inplace=True
+                columns=["TT (Sec)", "PR-AUC", "PR-AUC-Weighted", "PRC"],
+                errors="ignore",
+                inplace=True,
             )
             summary_html += (
                 f"<h2>{best_model_name}: Tuning Summary</h2>"

--- a/tools/tabularlearner/pycaret_predict.py
+++ b/tools/tabularlearner/pycaret_predict.py
@@ -4,14 +4,81 @@ import tempfile
 
 import h5py
 import joblib
+import numpy as np
 import pandas as pd
 from pycaret.classification import ClassificationExperiment
 from pycaret.regression import RegressionExperiment
-from sklearn.metrics import average_precision_score
-from utils import encode_image_to_base64, get_html_closing, get_html_template
+from sklearn.metrics import auc, precision_recall_curve
+from utils import (
+    build_tabbed_html,
+    encode_image_to_base64,
+    get_html_closing,
+    get_html_template,
+)
 
 
 LOG = logging.getLogger(__name__)
+
+
+def _weighted_ovr_pr_auc(y_true, y_score, labels=None):
+    y_true_series = pd.Series(y_true).reset_index(drop=True)
+    if labels is not None:
+        class_labels = list(labels)
+    else:
+        class_labels = list(pd.unique(y_true_series))
+        try:
+            class_labels = sorted(class_labels)
+        except Exception:
+            pass
+    if len(class_labels) < 2:
+        return np.nan
+
+    scores = np.asarray(y_score)
+    if len(scores) != len(y_true_series):
+        return np.nan
+
+    if len(class_labels) == 2:
+        try:
+            pos_label = 1 if 1 in class_labels else sorted(class_labels)[-1]
+        except Exception:
+            pos_label = class_labels[-1]
+        if scores.ndim == 2:
+            if scores.shape[1] < 2:
+                scores = scores.ravel()
+            else:
+                try:
+                    pos_idx = class_labels.index(pos_label)
+                except ValueError:
+                    pos_idx = scores.shape[1] - 1
+                scores = scores[:, min(pos_idx, scores.shape[1] - 1)]
+        precision, recall, _ = precision_recall_curve(
+            (y_true_series == pos_label).astype(int),
+            scores,
+        )
+        return auc(recall, precision)
+
+    if scores.ndim != 2 or scores.shape[1] < len(class_labels):
+        return np.nan
+
+    weighted_total = 0.0
+    support_total = 0
+    for class_idx, class_label in enumerate(class_labels):
+        y_true_bin = (y_true_series == class_label).astype(int)
+        if len(pd.unique(y_true_bin)) < 2:
+            continue
+        precision, recall, _ = precision_recall_curve(
+            y_true_bin,
+            scores[:, class_idx],
+        )
+        support = int(y_true_bin.sum())
+        weighted_total += auc(recall, precision) * support
+        support_total += support
+
+    return weighted_total / support_total if support_total else np.nan
+
+
+def pr_auc_curve_score(y_true, y_score):
+    return _weighted_ovr_pr_auc(y_true, y_score)
 
 
 class PyCaretModelEvaluator:
@@ -44,15 +111,14 @@ class ClassificationEvaluator(PyCaretModelEvaluator):
         if self.target:
             exp = ClassificationExperiment()
             names = data.columns.to_list()
-            LOG.error(f"Column names: {names}")
+            LOG.info(f"Column names: {names}")
             target_index = int(self.target) - 1
             target_name = names[target_index]
             exp.setup(data, target=target_name, test_data=data, index=False)
-            exp.add_metric(id='PR-AUC-Weighted',
-                           name='PR-AUC-Weighted',
+            exp.add_metric(id='PR-AUC',
+                           name='PR-AUC',
                            target='pred_proba',
-                           score_func=average_precision_score,
-                           average='weighted')
+                           score_func=pr_auc_curve_score)
             predictions = exp.predict_model(self.model)
             metrics = exp.pull()
             plots = ['confusion_matrix', 'auc', 'threshold', 'pr',
@@ -137,25 +203,18 @@ def generate_html_report(plots, metrics):
 
     metrics_html = metrics.to_html(index=False, classes="table")
 
-    html_content = f"""
-    {get_html_template()}
-    <h1>Model Evaluation Report</h1>
-    <div class="tabs">
-        <div class="tab" onclick="openTab(event, 'metrics')">Metrics</div>
-        <div class="tab" onclick="openTab(event, 'plots')">Plots</div>
-    </div>
-    <div id="metrics" class="tab-content">
-        <h2>Metrics</h2>
-        <table>
-            {metrics_html}
-        </table>
-    </div>
-    <div id="plots" class="tab-content">
-        <h2>Plots</h2>
-        {plots_html}
-    </div>
-    {get_html_closing()}
-    """
+    html_content = (
+        get_html_template()
+        + "<h1>Model Evaluation Report</h1>"
+        + build_tabbed_html(
+            "<h2>Metrics</h2><div class='table-wrapper'>" + metrics_html + "</div>",
+            "<h2>Plots</h2>" + plots_html,
+            None,
+            summary_tab_label="Metrics",
+            test_tab_label="Plots",
+        )
+        + get_html_closing()
+    )
 
     # Save HTML report
     with open("evaluation_report.html", "w") as html_file:

--- a/tools/tabularlearner/pycaret_train.py
+++ b/tools/tabularlearner/pycaret_train.py
@@ -159,8 +159,11 @@ def main():
     # Normalize cross-validation flags: --no_cross_validation overrides --cross_validation
     if args.no_cross_validation:
         args.cross_validation = False
-    # If --cross_validation was passed, args.cross_validation is True
-    # If neither was passed, args.cross_validation remains None
+    elif args.cross_validation is None:
+        args.cross_validation = True
+
+    if args.cross_validation and args.cross_validation_folds is None:
+        args.cross_validation_folds = 10
 
     # Build the model_kwargs dict from CLI args
     model_kwargs = {

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -180,9 +180,9 @@
             <param name="normalize" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Normalize Data" help="Whether to normalize data before training." />
             <param name="feature_selection" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Feature Selection" help="Whether to perform feature selection." />
             <conditional name="cross_validation">
-                <param name="enable_cross_validation" type="select" value="false" label="Enable Cross Validation?" help="Select whether to enable cross-validation." >
-                    <option value="false" selected="true">No</option>
-                    <option value="true">Yes</option>
+                <param name="enable_cross_validation" type="select" value="true" label="Enable Cross Validation?" help="Select whether to enable cross-validation." >
+                    <option value="true" selected="true">Yes</option>
+                    <option value="false">No</option>
                 </param>
                 <when value="false">
                     <!-- No additional parameters to show if the user selects 'No' -->
@@ -221,7 +221,7 @@
             <output name="model" file="expected_model_classification_customized.h5" compare="sim_size"/>
             <output name="comparison_result">
                 <assert_contents>
-                    <has_text text="Validation Summary" />
+                    <has_text text="Model Comparison" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Best Model Metric" />
@@ -245,7 +245,7 @@
             <output name="model" file="expected_model_classification_customized_cross_off.h5" compare="sim_size"/>
             <output name="comparison_result">
                 <assert_contents>
-                    <has_text text="Validation Summary" />
+                    <has_text text="Model Comparison" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                 </assert_contents>
@@ -258,11 +258,12 @@
             <param name="model_selection|model_type" value="classification"/>
             <param name="model_selection|classification_models" value="lightgbm"/>
             <param name="random_seed" value="42"/>
+            <param name="cross_validation|enable_cross_validation" value="false"/>
             <param name="tune_model" value="true"/>
             <output name="model" file="expected_model_classification.h5" compare="sim_size"/>
             <output name="comparison_result"> 
                 <assert_contents>
-                    <has_text text="Validation Summary" />
+                    <has_text text="Model Comparison" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                 </assert_contents>
@@ -281,10 +282,11 @@
             <param name="model_selection|model_type" value="classification"/>
             <param name="model_selection|classification_models" value="lightgbm"/>
             <param name="random_seed" value="42"/>
+            <param name="cross_validation|enable_cross_validation" value="false"/>
             <output name="model" file="expected_model_classification.h5" compare="sim_size"/>
             <output name="comparison_result"> 
                 <assert_contents>
-                    <has_text text="Validation Summary" />
+                    <has_text text="Model Comparison" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                 </assert_contents>
@@ -304,10 +306,11 @@
             <param name="model_selection|regression_models" value="gbr"/>
             <param name="model_selection|best_model_metric" value="RMSE"/>
             <param name="random_seed" value="42"/>
+            <param name="cross_validation|enable_cross_validation" value="false"/>
             <output name="model" file="expected_model_regression.h5" compare="sim_size" />
             <output name="comparison_result">
                 <assert_contents>
-                    <has_text text="Validation Summary" />
+                    <has_text text="Model Comparison" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Best Model Metric" />

--- a/tools/tabularlearner/utils.py
+++ b/tools/tabularlearner/utils.py
@@ -217,6 +217,7 @@ def build_tabbed_html(
     feature_html: str,
     explainer_html: Optional[str] = None,
     config_html: Optional[str] = None,
+    summary_tab_label: str = "Validation Summary",
 ) -> str:
     """
     Render the tabbed sections and an always-visible Help button.
@@ -233,11 +234,11 @@ def build_tabbed_html(
             '<div class="tab active" onclick="showTab(\'config\')">Experiment Summary</div>'
         )
         tabs.append(
-            '<div class="tab" onclick="showTab(\'summary\')">Validation Summary</div>'
+            f'<div class="tab" onclick="showTab(\'summary\')">{summary_tab_label}</div>'
         )
     else:
         tabs.append(
-            '<div class="tab active" onclick="showTab(\'summary\')">Validation Summary</div>'
+            f'<div class="tab active" onclick="showTab(\'summary\')">{summary_tab_label}</div>'
         )
     tabs.extend([
         '<div class="tab" onclick="showTab(\'test\')">Test Summary</div>',

--- a/tools/tabularlearner/utils.py
+++ b/tools/tabularlearner/utils.py
@@ -214,17 +214,16 @@ def get_html_closing() -> str:
 def build_tabbed_html(
     summary_html: str,
     test_html: str,
-    feature_html: str,
+    feature_html: Optional[str],
     explainer_html: Optional[str] = None,
     config_html: Optional[str] = None,
     summary_tab_label: str = "Validation Summary",
+    test_tab_label: str = "Test Summary",
+    feature_tab_label: str = "Feature Importance",
 ) -> str:
     """
     Render the tabbed sections and an always-visible Help button.
     """
-    # CSS
-    css = get_html_template().split("<body>")[1].rsplit("</style>", 1)[0] + "</style>"
-
     # Tabs header
     tabs = ['<div class="tabs">']
     default_active = "summary"
@@ -241,9 +240,12 @@ def build_tabbed_html(
             f'<div class="tab active" onclick="showTab(\'summary\')">{summary_tab_label}</div>'
         )
     tabs.extend([
-        '<div class="tab" onclick="showTab(\'test\')">Test Summary</div>',
-        '<div class="tab" onclick="showTab(\'feature\')">Feature Importance</div>',
+        f'<div class="tab" onclick="showTab(\'test\')">{test_tab_label}</div>',
     ])
+    if feature_html is not None:
+        tabs.append(
+            f'<div class="tab" onclick="showTab(\'feature\')">{feature_tab_label}</div>'
+        )
     if explainer_html:
         tabs.append(
             '<div class="tab" onclick="showTab(\'explainer\')">Explainer Plots</div>'
@@ -262,7 +264,8 @@ def build_tabbed_html(
         f'<div id="summary" class="tab-content {"active" if default_active == "summary" else ""}">{summary_html}</div>'
     )
     contents.append(f'<div id="test" class="tab-content">{test_html}</div>')
-    contents.append(f'<div id="feature" class="tab-content">{feature_html}</div>')
+    if feature_html is not None:
+        contents.append(f'<div id="feature" class="tab-content">{feature_html}</div>')
     if explainer_html:
         contents.append(
             f'<div id="explainer" class="tab-content">{explainer_html}</div>'
@@ -281,7 +284,7 @@ function showTab(id) {
 </script>
 """
 
-    return css + "\n" + tabs_section + "\n" + content_section + "\n" + js
+    return tabs_section + "\n" + content_section + "\n" + js
 
 
 def customize_figure_layout(fig, margin_dict=None):


### PR DESCRIPTION
Summary

Removes PR-AUC columns from the tabular learner’s cross-model Validation Summary and tuning summary tables in the HTML report.

Why

PR-AUC in the Validation Summary came from the candidate model comparison output, while PR-AUC in the Experiment Summary is recomputed for the selected model from validation prediction probabilities. These values can differ because they use different aggregation paths, which can confuse report readers.

Changes

Hide PR-AUC, PR-AUC-Weighted, and PRC from the Validation Summary display table.
Hide the same PR-AUC variants from the tuning summary display table.
Preserve the underlying model comparison results and selected-model PR-AUC calculation.
