### PR TITLE
Align Tabular Learner cross-validation reporting with PyCaret model selection

### DIFF
--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1829,26 +1829,44 @@ class BaseModelTrainer:
             if validation_enabled
             else "Internal Holdout Summary Across Candidate Models"
         )
-        model_selection_note = (
-            "Note: The candidate-model table reports PyCaret's internal "
-            "cross-validation metrics used to rank candidate models. Final "
-            "selected-model metrics are reported separately in Best Model "
-            "Performance."
-            if validation_enabled
-            else "Note: Cross-validation was disabled. The candidate-model "
-            "table reports PyCaret's internal holdout metrics used to rank "
-            "candidate models. "
-            "No final Validation column is shown."
-        )
-        tuning_note = (
-            "Note: The tuning table reports PyCaret's tuning output for the "
-            "selected model. It is separate from the final Train, Validation, "
-            "and Test metrics in Best Model Performance."
-            if validation_enabled
-            else "Note: The tuning table reports PyCaret's tuning output for "
-            "the selected model. It is separate from the final Train and Test "
-            "metrics in Best Model Performance."
-        )
+        if self.task_type == "classification":
+            model_selection_note = (
+                "Note: The candidate-model table reports PyCaret's internal "
+                "cross-validation metrics used to rank candidate models. Final "
+                "selected-model metrics are reported separately in Best Model "
+                "Performance."
+                if validation_enabled
+                else "Note: Cross-validation was disabled. The candidate-model "
+                "table reports PyCaret's internal holdout metrics used to rank "
+                "candidate models. "
+                "No final Validation column is shown."
+            )
+            tuning_note = (
+                "Note: The tuning table reports PyCaret's tuning output for the "
+                "selected model. It is separate from the final Train, Validation, "
+                "and Test metrics in Best Model Performance."
+                if validation_enabled
+                else "Note: The tuning table reports PyCaret's tuning output for "
+                "the selected model. It is separate from the final Train and Test "
+                "metrics in Best Model Performance."
+            )
+        else:
+            model_selection_note = (
+                "Note: The candidate-model table reports PyCaret's internal "
+                "cross-validation metrics used to rank candidate models. Final "
+                "selected-model holdout metrics are reported separately in Test "
+                "Summary."
+                if validation_enabled
+                else "Note: Cross-validation was disabled. The candidate-model "
+                "table reports PyCaret's internal holdout metrics used to rank "
+                "candidate models. Final selected-model holdout metrics are "
+                "reported separately in Test Summary."
+            )
+            tuning_note = (
+                "Note: The tuning table reports PyCaret's tuning output for the "
+                "selected model. It is separate from the final selected-model "
+                "holdout metrics in Test Summary."
+            )
         summary_html = (
             cv_fold_allocation_html
             + f"<h2>{summary_heading}</h2>"

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1715,10 +1715,13 @@ class BaseModelTrainer:
             "Remove Outliers",
             "Remove Multicollinearity",
             "Polynomial Features",
-            "Fix Imbalance",
             "Models",
-            "Probability Threshold",
         ]
+        if self.task_type == "classification":
+            display_keys.extend([
+                "Fix Imbalance",
+                "Probability Threshold",
+            ])
         setup_rows = []
         for key in display_keys:
             pk = key.lower().replace(" ", "_")
@@ -1820,6 +1823,7 @@ class BaseModelTrainer:
             "class_report": "Per-Class Metrics",
             "pr_auc": "Precision-Recall Curve",
             "roc_auc": "Receiver Operating Characteristic AUC",
+            "predicted_vs_actual": "Predicted vs Actual",
             "residuals": "Residuals Distribution",
             "error": "Prediction Error Distribution",
         }
@@ -1922,7 +1926,7 @@ class BaseModelTrainer:
                 "percentage_above_below",
             ]
         else:
-            summary_plots = ["learning", "vc", "parameter", "residuals"]
+            summary_plots = ["learning", "vc", "parameter"]
 
         for name in summary_plots:
             fig_or_fn = self.explainer_plots.pop(name, None)
@@ -1977,6 +1981,7 @@ class BaseModelTrainer:
                     )
                 ).rename("Predicted")
                 df_tp = pd.concat([y_true, y_pred], axis=1)
+                df_tp["Residual"] = df_tp["True"] - df_tp["Predicted"]
                 test_html += "<h2>True vs Predicted Values</h2>"
                 test_html += (
                     '<div class="table-wrapper" '
@@ -1994,7 +1999,7 @@ class BaseModelTrainer:
 
         # 5a) Explainer-substituted plots in order
         if self.task_type == "regression":
-            test_order = ["residuals"]
+            test_order = ["predicted_vs_actual", "residuals"]
         else:
             test_order = [
                 "confusion_matrix",
@@ -2049,10 +2054,12 @@ class BaseModelTrainer:
             # regression: explicitly include the 'error' plot,
             # before skipping
             if self.task_type == "regression" and (
-                name == "error"
+                name in {"error", "residuals"}
             ):
+                if name in rendered_test_plots:
+                    continue
                 title = plot_title_map.get(
-                    "error", "Prediction Error Distribution"
+                    name, name.replace("_", " ").title()
                 )
                 b64 = encode_image_to_base64(path)
                 test_html += (

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1823,7 +1823,7 @@ class BaseModelTrainer:
             "residuals": "Residuals Distribution",
             "error": "Prediction Error Distribution",
         }
-        summary_tab_label = "Model Comparison"
+        summary_tab_label = "Validation Summary"
         summary_heading = (
             "Internal Cross-Validation Summary Across Candidate Models"
             if validation_enabled

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1435,6 +1435,19 @@ class BaseModelTrainer:
             rows.append(row)
 
         df = pd.DataFrame(rows, columns=columns)
+        note = (
+            "Note: Train and Test metrics are computed by scoring the selected "
+            "best model on the training/CV pool and held-out test set. "
+            "Validation metrics are computed from pooled out-of-fold "
+            "predictions for the selected best model. These values can differ "
+            "from PyCaret's candidate-model table, which reports internal "
+            "fold-summary metrics used for ranking."
+            if validation_enabled
+            else "Note: Train and Test metrics are computed by scoring the "
+            "selected best model on the training and held-out test data. No "
+            "final Validation column is shown because cross-validation is "
+            "disabled."
+        )
         return (
             "<h2>Best Model Performance</h2>"
             + '<div class="table-wrapper">'
@@ -1443,6 +1456,7 @@ class BaseModelTrainer:
                 classes=["table", "sortable", "table-perf-summary"],
             )
             + "</div>"
+            + f"<p class='report-footnote'>{note}</p>"
         )
 
     @staticmethod

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -802,20 +802,22 @@ class BaseModelTrainer:
         df.sort_values("Label", inplace=True)
 
         note = (
-            "<p><em>Validation metrics use out-of-fold predictions across the "
-            "training/CV pool.</em></p>"
+            "<p class='report-footnote'>Note: Validation metrics use "
+            "out-of-fold predictions across the training/CV pool, so Dataset "
+            "Overview shows the pool instead of a separate fixed validation "
+            "count.</p>"
             if validation_enabled
             else ""
         )
         return (
             "<h2>Dataset Overview</h2>"
-            + note
             + '<div class="table-wrapper">'
             + df.to_html(
                 index=False,
                 classes=["table", "sortable", "table-dataset-overview"],
             )
             + "</div>"
+            + note
         )
 
     def _predict_with_thresholds(self, X, y_true):
@@ -1388,6 +1390,12 @@ class BaseModelTrainer:
             except Exception:
                 return str(value)
 
+        validation_enabled = getattr(self, "cross_validation", None) is not False
+        columns = ["Metric", "Train"]
+        if validation_enabled:
+            columns.append("Validation")
+        columns.append("Test")
+
         rows = []
         validation_preds = split_predictions.get("Validation")
         for metric in metric_names:
@@ -1398,13 +1406,14 @@ class BaseModelTrainer:
             )
             row.append(_fmt(train_val))
 
-            # Validation is shown only when validation predictions exist. This
-            # avoids mixing selected-model metrics with PyCaret comparison rows
-            # when cross-validation is disabled.
-            val_val = self._compute_metric_value(
-                metric, validation_preds, "Validation"
-            )
-            row.append(_fmt(val_val))
+            # Validation belongs only to final evaluation when user-facing
+            # cross-validation is enabled. PyCaret model-selection metrics are
+            # reported separately in the Model Comparison tab.
+            if validation_enabled:
+                val_val = self._compute_metric_value(
+                    metric, validation_preds, "Validation"
+                )
+                row.append(_fmt(val_val))
 
             # Test
             test_val = self._compute_metric_value(
@@ -1413,7 +1422,7 @@ class BaseModelTrainer:
             row.append(_fmt(test_val))
             rows.append(row)
 
-        df = pd.DataFrame(rows, columns=["Metric", "Train", "Validation", "Test"])
+        df = pd.DataFrame(rows, columns=columns)
         return (
             "<h2>Best Model Performance</h2>"
             + '<div class="table-wrapper">'
@@ -1635,12 +1644,10 @@ class BaseModelTrainer:
         header = f"<h2>Best Model: {best_model_name}</h2>"
 
         validation_enabled = getattr(self, "cross_validation", None) is not False
-        comparison_metric_prefix = "CV " if validation_enabled else "Comparison "
 
         # — Model Comparison & Configuration —
         val_df = self._prepare_model_comparison_display_df(
             self.results,
-            metric_prefix=comparison_metric_prefix,
         )
         dataset_overview_html = self._build_dataset_overview()
         performance_summary_html = self._build_performance_summary_table()
@@ -1662,9 +1669,20 @@ class BaseModelTrainer:
         }
         summary_tab_label = "Model Comparison"
         summary_heading = (
-            "Cross-Validation Model Comparison Across Candidate Models"
+            "Internal Cross-Validation Summary Across Candidate Models"
             if validation_enabled
-            else "Model Comparison Across Candidate Models"
+            else "Internal Holdout Summary Across Candidate Models"
+        )
+        model_selection_note = (
+            "Note: The candidate-model table reports PyCaret's internal "
+            "cross-validation metrics used to rank candidate models. Final "
+            "selected-model metrics are reported separately in Best Model "
+            "Performance."
+            if validation_enabled
+            else "Note: Cross-validation was disabled. The candidate-model "
+            "table reports PyCaret's internal holdout metrics used to rank "
+            "candidate models. "
+            "No final Validation column is shown."
         )
         summary_html = (
             f"<h2>{summary_heading}</h2>"
@@ -1676,7 +1694,6 @@ class BaseModelTrainer:
         if self.tuning_results is not None:
             tuning_df = self._prepare_model_comparison_display_df(
                 self.tuning_results,
-                metric_prefix=comparison_metric_prefix,
             )
             summary_html += (
                 f"<h2>{best_model_name}: Tuning Summary</h2>"
@@ -1684,6 +1701,8 @@ class BaseModelTrainer:
                 + tuning_df.to_html(index=False, classes="table sortable")
                 + "</div>"
             )
+
+        summary_html += f"<p class='report-footnote'>{model_selection_note}</p>"
 
         config_html = (
             header

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1684,11 +1684,21 @@ class BaseModelTrainer:
             "candidate models. "
             "No final Validation column is shown."
         )
+        tuning_note = (
+            "Note: The tuning table reports PyCaret's tuning output for the "
+            "selected model. It is separate from the final Train, Validation, "
+            "and Test metrics in Best Model Performance."
+            if validation_enabled
+            else "Note: The tuning table reports PyCaret's tuning output for "
+            "the selected model. It is separate from the final Train and Test "
+            "metrics in Best Model Performance."
+        )
         summary_html = (
             f"<h2>{summary_heading}</h2>"
             + '<div class="table-wrapper">'
             + val_df.to_html(index=False, classes="table sortable")
             + "</div>"
+            + f"<p class='report-footnote'>{model_selection_note}</p>"
         )
 
         if self.tuning_results is not None:
@@ -1700,9 +1710,8 @@ class BaseModelTrainer:
                 + '<div class="table-wrapper">'
                 + tuning_df.to_html(index=False, classes="table sortable")
                 + "</div>"
+                + f"<p class='report-footnote'>{tuning_note}</p>"
             )
-
-        summary_html += f"<p class='report-footnote'>{model_selection_note}</p>"
 
         config_html = (
             header

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -802,10 +802,10 @@ class BaseModelTrainer:
         df.sort_values("Label", inplace=True)
 
         note = (
-            "<p class='report-footnote'>Note: Validation metrics use "
-            "out-of-fold predictions across the training/CV pool, so Dataset "
-            "Overview shows the pool instead of a separate fixed validation "
-            "count.</p>"
+            "<p class='report-footnote'>Note: Because cross-validation "
+            "iteratively splits the training data into training and validation "
+            "folds, &ldquo;Training / CV Pool&rdquo; refers to one shared "
+            "dataset rather than separate fixed partitions.</p>"
             if validation_enabled
             else ""
         )
@@ -1096,9 +1096,7 @@ class BaseModelTrainer:
 
         df = pd.DataFrame(rows)
         note = (
-            "Note: Fold sizes are derived from the same cross-validation splitter "
-            "used for model selection and final out-of-fold validation metrics. "
-            "Sizes can differ by one sample, and group-aware folds can vary more "
+            "Note: Sizes can differ by one sample, and group-aware folds can vary more "
             "because rows with the same sample ID stay together."
         )
         return (
@@ -1564,19 +1562,6 @@ class BaseModelTrainer:
             rows.append(row)
 
         df = pd.DataFrame(rows, columns=columns)
-        note = (
-            "Note: Train and Test metrics are computed by scoring the selected "
-            "best model on the training/CV pool and held-out test set. "
-            "Validation metrics are computed from pooled out-of-fold "
-            "predictions for the selected best model. These values can differ "
-            "from PyCaret's candidate-model table, which reports internal "
-            "fold-summary metrics used for ranking."
-            if validation_enabled
-            else "Note: Train and Test metrics are computed by scoring the "
-            "selected best model on the training and held-out test data. No "
-            "final Validation column is shown because cross-validation is "
-            "disabled."
-        )
         return (
             "<h2>Best Model Performance</h2>"
             + '<div class="table-wrapper">'
@@ -1585,7 +1570,6 @@ class BaseModelTrainer:
                 classes=["table", "sortable", "table-perf-summary"],
             )
             + "</div>"
-            + f"<p class='report-footnote'>{note}</p>"
         )
 
     @staticmethod
@@ -1835,10 +1819,9 @@ class BaseModelTrainer:
         )
         if self.task_type == "classification":
             model_selection_note = (
-                "Note: The candidate-model table reports PyCaret's internal "
-                "cross-validation metrics used to rank candidate models. Final "
-                "selected-model metrics are reported separately in Best Model "
-                "Performance."
+                "Note: This table reports PyCaret's internal cross-validation "
+                "metrics used to rank candidate models. These values can "
+                "slightly differ from Best Model Performance table."
                 if validation_enabled
                 else "Note: Cross-validation was disabled. The candidate-model "
                 "table reports PyCaret's internal holdout metrics used to rank "

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1013,6 +1013,18 @@ class BaseModelTrainer:
         if len(X_df) != len(y_series):
             X_df = X_df.iloc[: len(y_series)].reset_index(drop=True)
 
+        cv_groups = getattr(self, "sample_id_series", None)
+        if cv_groups is not None:
+            cv_groups = pd.Series(cv_groups).reset_index(drop=True)
+            if len(cv_groups) != len(y_series):
+                LOG.warning(
+                    "Skipping group labels for validation metrics because "
+                    "group count (%s) does not match training rows (%s).",
+                    len(cv_groups),
+                    len(y_series),
+                )
+                cv_groups = None
+
         classes = list(getattr(self.best_model, "classes_", []))
         if len(classes) > 1:
             try:
@@ -1033,6 +1045,9 @@ class BaseModelTrainer:
 
         prob_thresh = getattr(self, "probability_threshold", None)
         n_jobs = getattr(self, "n_jobs", None)
+        cv_predict_kwargs = {"cv": cv_gen, "method": "predict_proba", "n_jobs": n_jobs}
+        if cv_groups is not None:
+            cv_predict_kwargs["groups"] = cv_groups
 
         y_scores = None
         try:
@@ -1040,9 +1055,7 @@ class BaseModelTrainer:
                 self.best_model,
                 X_df,
                 y_series,
-                cv=cv_gen,
-                method="predict_proba",
-                n_jobs=n_jobs,
+                **cv_predict_kwargs,
             )
             y_scores = np.asarray(proba)
         except Exception as exc:
@@ -1068,13 +1081,12 @@ class BaseModelTrainer:
             y_scores = y_scores[:, pos_idx]
         else:
             try:
+                cv_predict_kwargs["method"] = "predict"
                 y_pred = cross_val_predict(
                     self.best_model,
                     X_df,
                     y_series,
-                    cv=cv_gen,
-                    method="predict",
-                    n_jobs=n_jobs,
+                    **cv_predict_kwargs,
                 )
             except Exception as exc:
                 LOG.warning(

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1561,6 +1561,13 @@ class BaseModelTrainer:
             rows.append(row)
 
         df = pd.DataFrame(rows, columns=columns)
+        note = (
+            "Note: Train and Test metrics are computed by scoring the selected "
+            "best model on the training/CV pool and held-out test set. These "
+            "values can differ from PyCaret's candidate-model table."
+            if validation_enabled
+            else ""
+        )
         return (
             "<h2>Best Model Performance</h2>"
             + '<div class="table-wrapper">'
@@ -1569,6 +1576,7 @@ class BaseModelTrainer:
                 classes=["table", "sortable", "table-perf-summary"],
             )
             + "</div>"
+            + (f"<p class='report-footnote'>{note}</p>" if note else "")
         )
 
     @staticmethod

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -802,10 +802,9 @@ class BaseModelTrainer:
         df.sort_values("Label", inplace=True)
 
         note = (
-            "<p class='report-footnote'>Note: Because cross-validation "
-            "iteratively splits the training data into training and validation "
-            "folds, &ldquo;Training / CV Pool&rdquo; refers to one shared "
-            "dataset rather than separate fixed partitions.</p>"
+            "<p class='report-footnote'>Note: The Training / CV Pool column "
+            "shows the total samples used for training and validation rather "
+            "than separate fixed train and validation count columns.</p>"
             if validation_enabled
             else ""
         )

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -998,28 +998,58 @@ class BaseModelTrainer:
                     return val
             return None
 
-        X_train = _get_from_config(["X_train_transformed", "X_train"])
-        y_split = _get_from_config(["y_train_transformed", "y_train"])
+        # Prefer the original training/CV pool. Transformed training features
+        # can have fewer rows when preprocessing removes samples, for example
+        # with remove_outliers=True, which makes them unsuitable for reporting
+        # the user-visible CV fold allocation.
+        X_train = _get_from_config(["X_train", "X_train_transformed"])
+        y_split = _get_from_config(["y_train", "y_train_transformed"])
         y_display = _get_from_config(["y_train", "y_train_transformed"])
-        if X_train is None or y_split is None:
+        if (
+            y_split is None
+            and self.data is not None
+            and self.target in self.data.columns
+        ):
+            y_split = self.data[self.target]
+            y_display = y_split
+        if y_split is None:
             return ""
 
-        X_df = pd.DataFrame(X_train).reset_index(drop=True)
         y_split_series = pd.Series(y_split).reset_index(drop=True)
         y_display_series = pd.Series(
             y_display if y_display is not None else y_split
         ).reset_index(drop=True)
-        if (
-            X_df.empty
-            or y_split_series.empty
-            or len(X_df) != len(y_split_series)
-            or len(y_display_series) != len(y_split_series)
-        ):
-            LOG.warning(
-                "Skipping CV fold allocation table because training data and labels "
-                "could not be aligned."
-            )
+        if y_split_series.empty:
             return ""
+
+        if len(y_display_series) != len(y_split_series):
+            LOG.warning(
+                "Using split labels for CV fold allocation display because display "
+                "labels could not be aligned."
+            )
+            y_display_series = y_split_series
+
+        X_df = None
+        if X_train is not None:
+            try:
+                candidate_X = pd.DataFrame(X_train).reset_index(drop=True)
+                if len(candidate_X) == len(y_split_series):
+                    X_df = candidate_X
+            except Exception:
+                X_df = None
+        if (
+            X_df is None
+            and self.data is not None
+            and self.target in self.data.columns
+            and len(self.data) == len(y_split_series)
+        ):
+            X_df = self.data.drop(columns=[self.target]).reset_index(drop=True)
+        if X_df is None:
+            LOG.warning(
+                "Using row indices for CV fold allocation table because training "
+                "features could not be aligned with labels."
+            )
+            X_df = pd.DataFrame({"_row": range(len(y_split_series))})
 
         cv_gen = self._get_cv_generator(y_split_series)
         if cv_gen is None:

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1093,7 +1093,18 @@ class BaseModelTrainer:
                 row["Validation Label Counts"] = _format_label_counts(validation_idx)
             rows.append(row)
 
+        column_order = ["Fold", "Train Samples"]
+        if self.task_type == "classification":
+            column_order.append("Train Label Counts")
+        column_order.append("Validation Samples")
+        if self.task_type == "classification":
+            column_order.append("Validation Label Counts")
+        if cv_groups is not None:
+            column_order.append("Train Groups")
+            column_order.append("Validation Groups")
+
         df = pd.DataFrame(rows)
+        df = df[[column for column in column_order if column in df.columns]]
         note = (
             "Note: Sizes can differ by one sample, and group-aware folds can vary more "
             "because rows with the same sample ID stay together."

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -927,9 +927,6 @@ class BaseModelTrainer:
         Build a cross-validation splitter that mirrors the experiment's
         configuration. Returns None when CV is disabled or not applicable.
         """
-        if self.task_type != "classification":
-            return None
-
         if getattr(self, "cross_validation", None) is False:
             return None
 
@@ -982,6 +979,138 @@ class BaseModelTrainer:
         except Exception as exc:
             LOG.warning("Could not build CV generator: %s", exc)
             return None
+
+    def _build_cv_fold_allocation_table(self):
+        """
+        Build an HTML table showing the train/validation sample allocation for
+        each cross-validation fold. This makes the fold sizes visible before
+        the PyCaret candidate-model summary.
+        """
+        if getattr(self, "cross_validation", None) is False:
+            return ""
+
+        def _get_from_config(keys):
+            for key in keys:
+                try:
+                    val = self.exp.get_config(key)
+                except Exception:
+                    val = getattr(self.exp, key, None)
+                if val is not None:
+                    return val
+            return None
+
+        X_train = _get_from_config(["X_train_transformed", "X_train"])
+        y_split = _get_from_config(["y_train_transformed", "y_train"])
+        y_display = _get_from_config(["y_train", "y_train_transformed"])
+        if X_train is None or y_split is None:
+            return ""
+
+        X_df = pd.DataFrame(X_train).reset_index(drop=True)
+        y_split_series = pd.Series(y_split).reset_index(drop=True)
+        y_display_series = pd.Series(
+            y_display if y_display is not None else y_split
+        ).reset_index(drop=True)
+        if (
+            X_df.empty
+            or y_split_series.empty
+            or len(X_df) != len(y_split_series)
+            or len(y_display_series) != len(y_split_series)
+        ):
+            LOG.warning(
+                "Skipping CV fold allocation table because training data and labels "
+                "could not be aligned."
+            )
+            return ""
+
+        cv_gen = self._get_cv_generator(y_split_series)
+        if cv_gen is None:
+            return ""
+
+        cv_groups = getattr(self, "sample_id_series", None)
+        if cv_groups is not None:
+            cv_groups = pd.Series(cv_groups).reset_index(drop=True)
+            if len(cv_groups) != len(y_split_series):
+                LOG.warning(
+                    "Skipping group counts in CV fold allocation table because "
+                    "group count (%s) does not match training rows (%s).",
+                    len(cv_groups),
+                    len(y_split_series),
+                )
+                cv_groups = None
+
+        try:
+            splits = list(cv_gen.split(X_df, y_split_series, groups=cv_groups))
+        except TypeError:
+            try:
+                splits = list(cv_gen.split(X_df, y_split_series))
+            except Exception as exc:
+                LOG.warning("Could not build CV fold allocation table: %s", exc)
+                return ""
+        except Exception as exc:
+            LOG.warning("Could not build CV fold allocation table: %s", exc)
+            return ""
+
+        if not splits:
+            return ""
+
+        rows = []
+        label_values = []
+        if self.task_type == "classification":
+            y_display_series = self._decode_class_labels_for_display(y_display_series)
+            label_values = pd.unique(y_display_series)
+            try:
+                label_values = sorted(label_values, key=lambda item: str(item))
+            except Exception:
+                label_values = list(label_values)
+
+        def _format_label_counts(indices):
+            if self.task_type != "classification":
+                return None
+            series = pd.Series(y_display_series).iloc[list(indices)].reset_index(drop=True)
+            parts = []
+            for label in label_values:
+                if pd.isna(label):
+                    count = int(series.isna().sum())
+                    label_text = "NaN"
+                else:
+                    count = int((series == label).sum())
+                    label_text = str(label)
+                parts.append(f"{label_text}: {count}")
+            return ", ".join(parts)
+
+        for fold_num, (train_idx, validation_idx) in enumerate(splits, start=1):
+            row = {
+                "Fold": fold_num,
+                "Train Samples": len(train_idx),
+                "Validation Samples": len(validation_idx),
+            }
+            if cv_groups is not None:
+                row["Train Groups"] = int(pd.Series(cv_groups).iloc[list(train_idx)].nunique(dropna=False))
+                row["Validation Groups"] = int(
+                    pd.Series(cv_groups).iloc[list(validation_idx)].nunique(dropna=False)
+                )
+            if self.task_type == "classification":
+                row["Train Label Counts"] = _format_label_counts(train_idx)
+                row["Validation Label Counts"] = _format_label_counts(validation_idx)
+            rows.append(row)
+
+        df = pd.DataFrame(rows)
+        note = (
+            "Note: Fold sizes are derived from the same cross-validation splitter "
+            "used for model selection and final out-of-fold validation metrics. "
+            "Sizes can differ by one sample, and group-aware folds can vary more "
+            "because rows with the same sample ID stay together."
+        )
+        return (
+            "<h2>Cross-Validation Fold Allocation</h2>"
+            + '<div class="table-wrapper">'
+            + df.to_html(
+                index=False,
+                classes=["table", "sortable", "table-cv-fold-allocation"],
+            )
+            + "</div>"
+            + f"<p class='report-footnote'>{note}</p>"
+        )
 
     def _get_cross_validated_predictions(self, X, y):
         """
@@ -1677,6 +1806,7 @@ class BaseModelTrainer:
         )
         dataset_overview_html = self._build_dataset_overview()
         performance_summary_html = self._build_performance_summary_table()
+        cv_fold_allocation_html = self._build_cv_fold_allocation_table()
         # mapping raw plot keys to user-friendly titles
         plot_title_map = {
             "learning": "Learning Curve",
@@ -1720,7 +1850,8 @@ class BaseModelTrainer:
             "metrics in Best Model Performance."
         )
         summary_html = (
-            f"<h2>{summary_heading}</h2>"
+            cv_fold_allocation_html
+            + f"<h2>{summary_heading}</h2>"
             + '<div class="table-wrapper">'
             + val_df.to_html(index=False, classes="table sortable")
             + "</div>"

--- a/tools/tabularlearner/pycaret_train.py
+++ b/tools/tabularlearner/pycaret_train.py
@@ -40,8 +40,8 @@ def main():
     parser.add_argument(
         "--cross_validation",
         action="store_true",
-        default=None,
-        help="Enable cross-validation for PyCaret setup",
+        default=True,
+        help="Enable cross-validation for PyCaret setup (default: enabled)",
     )
     parser.add_argument(
         "--no_cross_validation",
@@ -156,11 +156,10 @@ def main():
         except ValueError:
             n_jobs = 1
 
-    # Normalize cross-validation flags: --no_cross_validation overrides --cross_validation
+    # Normalize cross-validation flags: enabled by default, with
+    # --no_cross_validation as the explicit override.
     if args.no_cross_validation:
         args.cross_validation = False
-    elif args.cross_validation is None:
-        args.cross_validation = True
 
     if args.cross_validation and args.cross_validation_folds is None:
         args.cross_validation_folds = 10

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -225,6 +225,8 @@
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Best Model Metric" />
+                    <has_text text="Cross-Validation Fold Allocation" />
+                    <has_text text="Validation Samples" />
                     <has_text text="Internal Cross-Validation Summary Across Candidate Models" />
                     <has_text text="Validation metrics use out-of-fold predictions across the training/CV pool" />
                     <has_text text="Validation metrics are computed from pooled out-of-fold predictions for the selected best model" />

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -271,6 +271,7 @@
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Internal Holdout Summary Across Candidate Models" />
+                    <has_text text="The tuning table reports PyCaret's tuning output for the selected model" />
                 </assert_contents>
             </output>
             <output name="best_model_csv">

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -221,7 +221,7 @@
             <output name="model" file="expected_model_classification_customized.h5" compare="sim_size"/>
             <output name="comparison_result">
                 <assert_contents>
-                    <has_text text="Model Comparison" />
+                    <has_text text="Validation Summary" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Best Model Metric" />
@@ -250,7 +250,7 @@
             <output name="model" file="expected_model_classification_customized_cross_off.h5" compare="sim_size"/>
             <output name="comparison_result">
                 <assert_contents>
-                    <has_text text="Model Comparison" />
+                    <has_text text="Validation Summary" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Internal Holdout Summary Across Candidate Models" />
@@ -271,7 +271,7 @@
             <output name="model" file="expected_model_classification.h5" compare="sim_size"/>
             <output name="comparison_result"> 
                 <assert_contents>
-                    <has_text text="Model Comparison" />
+                    <has_text text="Validation Summary" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Internal Holdout Summary Across Candidate Models" />
@@ -296,7 +296,7 @@
             <output name="model" file="expected_model_classification.h5" compare="sim_size"/>
             <output name="comparison_result"> 
                 <assert_contents>
-                    <has_text text="Model Comparison" />
+                    <has_text text="Validation Summary" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Internal Holdout Summary Across Candidate Models" />
@@ -321,7 +321,7 @@
             <output name="model" file="expected_model_regression.h5" compare="sim_size" />
             <output name="comparison_result">
                 <assert_contents>
-                    <has_text text="Model Comparison" />
+                    <has_text text="Validation Summary" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Best Model Metric" />

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -326,7 +326,7 @@
                     <has_text text="Feature Importance" />
                     <has_text text="Best Model Metric" />
                     <has_text text="Internal Holdout Summary Across Candidate Models" />
-                    <has_text text="No final Validation column is shown." />
+                    <has_text text="Final selected-model holdout metrics are reported separately in Test Summary." />
                     <has_text text="RMSE" />
                 </assert_contents>
             </output>

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -75,8 +75,8 @@
                 </param>
                 <when value="yes">
                     <param name="test_file" type="data" format="csv,tabular" label="Test dataset"
-                           help="If a test dataset is provided, the input dataset will be split into training and validation sets only.
-                                 If not, the tool will split your input into training, validation, and test automatically." />
+                           help="If a test dataset is provided, the training dataset is used as the training/CV pool and the test dataset is used for final test metrics.
+                                 If no test dataset is provided, Train Size controls the train/test split. When cross-validation is enabled, validation metrics use out-of-fold predictions from the training/CV pool." />
                 </when>
                 <when value="no">
                     <!-- Nothing extra shown -->
@@ -180,15 +180,15 @@
             <param name="normalize" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Normalize Data" help="Whether to normalize data before training." />
             <param name="feature_selection" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Feature Selection" help="Whether to perform feature selection." />
             <conditional name="cross_validation">
-                <param name="enable_cross_validation" type="select" value="true" label="Enable Cross Validation?" help="Select whether to enable cross-validation." >
-                    <option value="true" selected="true">Yes</option>
+                <param name="enable_cross_validation" type="select" value="true" label="Enable Cross Validation?" help="Enabled by default. When enabled, PyCaret ranks candidate models with cross-validation and the report shows final Validation metrics from out-of-fold predictions. Select No to use PyCaret holdout ranking and omit the final Validation column." >
+                    <option value="true" selected="true">Yes (default)</option>
                     <option value="false">No</option>
                 </param>
                 <when value="false">
                     <!-- No additional parameters to show if the user selects 'No' -->
                 </when>
                 <when value="true">
-                    <param name="cross_validation_folds" type="integer" value="10" min="2" max="20" label="Cross Validation Folds" help="Number of folds to use for cross-validation." />
+                    <param name="cross_validation_folds" type="integer" value="10" min="2" max="20" label="Cross Validation Folds" help="Number of folds to use for cross-validation. Default is 10." />
                 </when>
             </conditional>
             <param name="remove_outliers" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Remove Outliers" help="Whether to remove outliers from the input dataset before training." />
@@ -225,6 +225,8 @@
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Best Model Metric" />
+                    <has_text text="Internal Cross-Validation Summary Across Candidate Models" />
+                    <has_text text="Validation metrics use out-of-fold predictions across the training/CV pool" />
                     <has_text text="F1" />
                 </assert_contents>
             </output>
@@ -248,6 +250,8 @@
                     <has_text text="Model Comparison" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
+                    <has_text text="Internal Holdout Summary Across Candidate Models" />
+                    <has_text text="No final Validation column is shown." />
                 </assert_contents>
             </output>
             <output name="best_model_csv" value="expected_best_model_classification_customized_cross_off.csv" />
@@ -266,6 +270,7 @@
                     <has_text text="Model Comparison" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
+                    <has_text text="Internal Holdout Summary Across Candidate Models" />
                 </assert_contents>
             </output>
             <output name="best_model_csv">
@@ -289,6 +294,7 @@
                     <has_text text="Model Comparison" />
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
+                    <has_text text="Internal Holdout Summary Across Candidate Models" />
                 </assert_contents>
             </output>
             <output name="best_model_csv">
@@ -314,6 +320,8 @@
                     <has_text text="Test Summary" />
                     <has_text text="Feature Importance" />
                     <has_text text="Best Model Metric" />
+                    <has_text text="Internal Holdout Summary Across Candidate Models" />
+                    <has_text text="No final Validation column is shown." />
                     <has_text text="RMSE" />
                 </assert_contents>
             </output>

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -228,8 +228,8 @@
                     <has_text text="Cross-Validation Fold Allocation" />
                     <has_text text="Validation Samples" />
                     <has_text text="Internal Cross-Validation Summary Across Candidate Models" />
-                    <has_text text="Validation metrics use out-of-fold predictions across the training/CV pool" />
-                    <has_text text="Validation metrics are computed from pooled out-of-fold predictions for the selected best model" />
+                    <has_text text="Because cross-validation iteratively splits the training data into training and validation folds" />
+                    <has_text text="These values can slightly differ from Best Model Performance table." />
                     <has_text text="F1" />
                 </assert_contents>
             </output>
@@ -255,7 +255,6 @@
                     <has_text text="Feature Importance" />
                     <has_text text="Internal Holdout Summary Across Candidate Models" />
                     <has_text text="No final Validation column is shown." />
-                    <has_text text="No final Validation column is shown because cross-validation is disabled." />
                 </assert_contents>
             </output>
             <output name="best_model_csv" value="expected_best_model_classification_customized_cross_off.csv" />

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -327,6 +327,8 @@
                     <has_text text="Best Model Metric" />
                     <has_text text="Internal Holdout Summary Across Candidate Models" />
                     <has_text text="Final selected-model holdout metrics are reported separately in Test Summary." />
+                    <has_text text="True vs Predicted Values" />
+                    <has_text text="Residual" />
                     <has_text text="RMSE" />
                 </assert_contents>
             </output>

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -229,6 +229,7 @@
                     <has_text text="Validation Samples" />
                     <has_text text="Internal Cross-Validation Summary Across Candidate Models" />
                     <has_text text="The Training / CV Pool column shows the total samples used for training and validation" />
+                    <has_text text="Train and Test metrics are computed by scoring the selected best model on the training/CV pool and held-out test set" />
                     <has_text text="These values can slightly differ from Best Model Performance table." />
                     <has_text text="F1" />
                 </assert_contents>

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -227,6 +227,7 @@
                     <has_text text="Best Model Metric" />
                     <has_text text="Internal Cross-Validation Summary Across Candidate Models" />
                     <has_text text="Validation metrics use out-of-fold predictions across the training/CV pool" />
+                    <has_text text="Validation metrics are computed from pooled out-of-fold predictions for the selected best model" />
                     <has_text text="F1" />
                 </assert_contents>
             </output>
@@ -252,6 +253,7 @@
                     <has_text text="Feature Importance" />
                     <has_text text="Internal Holdout Summary Across Candidate Models" />
                     <has_text text="No final Validation column is shown." />
+                    <has_text text="No final Validation column is shown because cross-validation is disabled." />
                 </assert_contents>
             </output>
             <output name="best_model_csv" value="expected_best_model_classification_customized_cross_off.csv" />

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -228,7 +228,7 @@
                     <has_text text="Cross-Validation Fold Allocation" />
                     <has_text text="Validation Samples" />
                     <has_text text="Internal Cross-Validation Summary Across Candidate Models" />
-                    <has_text text="Because cross-validation iteratively splits the training data into training and validation folds" />
+                    <has_text text="The Training / CV Pool column shows the total samples used for training and validation" />
                     <has_text text="These values can slightly differ from Best Model Performance table." />
                     <has_text text="F1" />
                 </assert_contents>

--- a/tools/tabularlearner/utils.py
+++ b/tools/tabularlearner/utils.py
@@ -74,6 +74,10 @@ def get_html_template() -> str:
           .table-perf-summary th:nth-child(n+2) {
               text-align: center;
           }
+          .table-cv-fold-allocation td,
+          .table-cv-fold-allocation th {
+              text-align: center;
+          }
           .table-setup-params td:nth-child(2),
           .table-setup-params th:nth-child(2) {
               text-align: center;

--- a/tools/tabularlearner/utils.py
+++ b/tools/tabularlearner/utils.py
@@ -86,6 +86,12 @@ def get_html_template() -> str:
           .table-fi-scope th:nth-child(2) {
               text-align: center;
           }
+          .report-footnote {
+              margin: -0.5rem 0 1rem;
+              color: #666;
+              font-size: 0.88rem;
+              line-height: 1.35;
+          }
 
           .plot {
               text-align: center;


### PR DESCRIPTION
# PR: Clarify Cross-Validation vs Final Model Metrics in Tabular Learner Reports

This PR aligns the Tabular Learner report with the actual source of each metric so users can clearly distinguish final Train/Validation/Test performance from PyCaret’s internal model-selection metrics.

Previously, the report could imply that all “Validation” numbers came from the same split. In practice, PyCaret uses `compare_models()` metrics for candidate model ranking, while the report separately computes final metrics for the selected best model. This created confusing number conflicts, especially when cross-validation was disabled.

---

## Changes

### Cross-validation defaults and behavior

- Cross-validation is now explicitly enabled by default:
  - CLI default is `cross_validation=True`
  - XML UI shows **Yes (default)**
  - Default fold count remains `10`

### When `cross_validation = no`

- PyCaret uses holdout-based model comparison
- The final **Best Model Performance** table omits the **Validation** column

### When `cross_validation = yes`

- PyCaret uses internal cross-validation for candidate ranking
- Final **Best Model Performance** includes:
  - Train
  - Validation
  - Test
- Validation metrics are based on out-of-fold predictions for the selected best model

### Report and table updates

- Renamed the model comparison table dynamically:
  - **CV enabled:**  
    *Internal Cross-Validation Summary Across Candidate Models*
  - **CV disabled:**  
    *Internal Holdout Summary Across Candidate Models*

- Removed metric column prefixes from the PyCaret comparison table because the section title now explains the source

- Added footnotes below tables to clarify metric provenance without cluttering the report

- Added a separate tuning-summary footnote so tuning metrics are not confused with final Train/Validation/Test metrics

### Dataset overview wording

- Updated **Dataset Overview** wording to use:
  - **Training / CV Pool** when CV is enabled

This avoids implying the existence of a fixed validation dataset during out-of-fold validation.

### Group-aware CV alignment

- Preserved group-aware CV alignment by passing sample groups into out-of-fold validation metric generation when sample-ID grouping is active

### Tests

- Updated XML tests to assert:
  - The new CV/holdout headings
  - The new explanatory text

---

## Why

The goal is to make the report consistent with both user intent and PyCaret behavior:

- PyCaret candidate-ranking metrics belong in the model comparison section
- Final selected-model metrics belong in **Best Model Performance**
- The Validation column should only appear when final validation metrics are actually being computed
- Users should be able to tell where each number came from without needing to understand PyCaret internals.