### PR TITLE
Cap Tabular Learner explainability work to keep report generation responsive

### DIFF
--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -7,6 +7,7 @@ import h5py
 import joblib
 import numpy as np
 import pandas as pd
+from explainability_limits import limit_explainability_data
 from feature_help_modal import get_feature_metrics_help_modal
 from feature_importance import FeatureImportanceAnalyzer
 from sklearn.metrics import (
@@ -133,6 +134,8 @@ class BaseModelTrainer:
         self.plots = {}
         self.explainer_plots = {}
         self.plots_explainer_html = None
+        self.explainer_scope = None
+        self.explainer_dashboard_importance_skipped = False
         self.trees = []
         self.user_kwargs = kwargs.copy()
         for key, value in self.user_kwargs.items():
@@ -505,6 +508,37 @@ class BaseModelTrainer:
         self.exp.setup(self.data, **self.setup_params)
         self._capture_imputed_training_data()
         self.setup_params.update(self.user_kwargs)
+
+    def _limit_explainer_data(
+        self,
+        X,
+        y=None,
+        context="ExplainerDashboard",
+        cap_features=True,
+    ):
+        """
+        Bound expensive ExplainerDashboard SHAP/permutation/PDP inputs.
+
+        Training, model selection, and final metrics keep using the full data;
+        this limiter only affects report explainability plots.
+        """
+        X_limited, y_limited, scope = limit_explainability_data(
+            X,
+            y,
+            model=self.best_model,
+            max_features=getattr(self, "plot_feature_limit", 30),
+            max_rows=getattr(self, "_shap_row_cap", None),
+            random_seed=self.random_seed,
+            polynomial_features=getattr(self, "polynomial_features", False),
+            cap_features=cap_features,
+            context=context,
+        )
+        self.explainer_scope = scope
+        return X_limited, y_limited
+
+    def _explainer_feature_count_exceeds_cap(self):
+        scope = getattr(self, "explainer_scope", None)
+        return scope is not None and scope.total_features > scope.feature_cap
 
     def _capture_imputed_training_data(self):
         """
@@ -2126,19 +2160,59 @@ class BaseModelTrainer:
             max_plot_features=self.plot_feature_limit,
             processed_data=self.imputed_training_data,
             max_shap_rows=self._shap_row_cap,
+            polynomial_features=getattr(self, "polynomial_features", False),
         )
         fi_html = fi_analyzer.run()
-        # Add a small table to show SHAP feature caps near the Best Model header.
+        # Add a small table to show explainability caps near the Best Model header.
         cap_rows = []
-        if fi_analyzer.shap_total_features is not None:
-            cap_rows.append(
-                ("Total transformed features", fi_analyzer.shap_total_features)
-            )
-        if fi_analyzer.shap_used_features is not None:
-            cap_rows.append(
-                ("Features used in SHAP", fi_analyzer.shap_used_features)
-            )
+        custom_scope = getattr(fi_analyzer, "shap_scope", None)
+        if custom_scope is not None:
+            cap_rows.extend([
+                ("Custom SHAP rows", f"{custom_scope.used_rows} of {custom_scope.total_rows}"),
+                (
+                    "Custom SHAP transformed features",
+                    f"{custom_scope.used_features} of {custom_scope.total_features}",
+                ),
+            ])
+        elif fi_analyzer.shap_total_features is not None:
+            cap_rows.append((
+                "Custom SHAP transformed features",
+                f"{fi_analyzer.shap_used_features} of {fi_analyzer.shap_total_features}",
+            ))
+        explainer_scope = getattr(self, "explainer_scope", None)
+        if explainer_scope is not None:
+            cap_rows.extend([
+                (
+                    "ExplainerDashboard rows",
+                    f"{explainer_scope.used_rows} of {explainer_scope.total_rows}",
+                ),
+                (
+                    "ExplainerDashboard transformed features",
+                    f"{explainer_scope.used_features} of {explainer_scope.total_features}",
+                ),
+            ])
+        if getattr(self, "explainer_dashboard_importance_skipped", False):
+            cap_rows.append((
+                "ExplainerDashboard SHAP/permutation importance",
+                "Skipped; custom capped SHAP is shown instead",
+            ))
+        if getattr(self, "polynomial_features", False):
+            cap_rows.append((
+                "Polynomial feature cap",
+                "Top 15 features and at most 200 rows",
+            ))
         if cap_rows:
+            capped = []
+            for scope in (custom_scope, explainer_scope):
+                if scope is not None and (scope.rows_capped or scope.features_capped):
+                    capped.append(scope)
+            note = ""
+            if capped:
+                note = (
+                    "<p class='report-footnote'>Note: Explainability plots were "
+                    "computed on a capped subset of rows and transformed features "
+                    "to keep report generation responsive after model training.</p>"
+                )
             cap_table = (
                 "<div class='table-wrapper'>"
                 "<table class='table sortable table-fi-scope'>"
@@ -2149,6 +2223,7 @@ class BaseModelTrainer:
                     for label, value in cap_rows
                 )
                 + "</tbody></table></div>"
+                + note
             )
             feature_html += cap_table
         feature_html += fi_html

--- a/tools/tabularlearner/explainability_limits.py
+++ b/tools/tabularlearner/explainability_limits.py
@@ -1,0 +1,165 @@
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+LOG = logging.getLogger(__name__)
+
+
+@dataclass
+class ExplainabilityScope:
+    context: str
+    total_rows: int
+    used_rows: int
+    total_features: int
+    used_features: int
+    row_cap: int
+    feature_cap: int
+    polynomial_features: bool = False
+
+    @property
+    def rows_capped(self):
+        return self.used_rows < self.total_rows
+
+    @property
+    def features_capped(self):
+        return self.used_features < self.total_features
+
+
+def adaptive_row_cap(n_rows, polynomial_features=False):
+    if n_rows <= 500:
+        cap = n_rows
+    elif n_rows <= 5000:
+        cap = 500
+    else:
+        cap = min(1000, max(1, int(n_rows * 0.1)))
+    if polynomial_features:
+        cap = min(cap, 200)
+    return max(0, int(cap))
+
+
+def feature_cap(default_cap=30, polynomial_features=False):
+    try:
+        cap = int(default_cap)
+    except (TypeError, ValueError):
+        cap = 30
+    if cap <= 0:
+        cap = 30
+    if polynomial_features:
+        cap = min(cap, 15)
+    return cap
+
+
+def _model_importance_scores(model, columns):
+    if model is None:
+        return None
+    if hasattr(model, "feature_importances_"):
+        values = np.asarray(model.feature_importances_)
+    elif hasattr(model, "coef_"):
+        values = np.asarray(model.coef_)
+        if values.ndim > 1:
+            values = np.mean(np.abs(values), axis=0)
+        else:
+            values = np.abs(values)
+    else:
+        return None
+    values = np.asarray(values).ravel()
+    if len(values) != len(columns):
+        return None
+    return pd.Series(values, index=columns).abs()
+
+
+def select_feature_columns(frame, model=None, max_features=30):
+    if frame is None:
+        return []
+    columns = list(frame.columns)
+    if max_features is None or max_features <= 0 or len(columns) <= max_features:
+        return columns
+
+    scores = _model_importance_scores(model, columns)
+    if scores is None:
+        try:
+            numeric_frame = frame.select_dtypes(include=["number"])
+            scores = numeric_frame.var().fillna(0).abs()
+        except Exception as exc:
+            LOG.warning(
+                "Could not rank transformed features by variance; using input order: %s",
+                exc,
+            )
+            return columns[:max_features]
+
+    ranked = [col for col in scores.sort_values(ascending=False).index if col in columns]
+    if len(ranked) < max_features:
+        ranked.extend(col for col in columns if col not in ranked)
+    return ranked[:max_features]
+
+
+def limit_explainability_data(
+    X,
+    y=None,
+    *,
+    model=None,
+    max_features=30,
+    max_rows=None,
+    random_seed=42,
+    polynomial_features=False,
+    cap_features=True,
+    context="Explainability",
+):
+    X_limited = pd.DataFrame(X).copy().reset_index(drop=True)
+    y_limited = None
+    if y is not None:
+        y_limited = pd.Series(y).reset_index(drop=True)
+        if len(y_limited) != len(X_limited):
+            y_limited = y_limited.iloc[: len(X_limited)].reset_index(drop=True)
+            X_limited = X_limited.iloc[: len(y_limited)].reset_index(drop=True)
+
+    total_rows, total_features = X_limited.shape
+    feature_limit = feature_cap(max_features, polynomial_features)
+    row_limit = (
+        adaptive_row_cap(total_rows, polynomial_features)
+        if max_rows is None
+        else min(int(max_rows), total_rows)
+    )
+    row_limit = max(0, row_limit)
+
+    if cap_features:
+        selected_columns = select_feature_columns(
+            X_limited,
+            model=model,
+            max_features=feature_limit,
+        )
+        if selected_columns and len(selected_columns) < total_features:
+            LOG.info(
+                "%s limited to top %s of %s transformed features.",
+                context,
+                len(selected_columns),
+                total_features,
+            )
+            X_limited = X_limited[selected_columns]
+
+    if total_rows > row_limit:
+        LOG.info(
+            "%s limited to %s of %s rows.",
+            context,
+            row_limit,
+            total_rows,
+        )
+        sampled_index = X_limited.sample(row_limit, random_state=random_seed).index
+        sampled_index = sorted(sampled_index.tolist())
+        X_limited = X_limited.loc[sampled_index].reset_index(drop=True)
+        if y_limited is not None:
+            y_limited = y_limited.loc[sampled_index].reset_index(drop=True)
+
+    scope = ExplainabilityScope(
+        context=context,
+        total_rows=total_rows,
+        used_rows=len(X_limited),
+        total_features=total_features,
+        used_features=X_limited.shape[1],
+        row_cap=row_limit,
+        feature_cap=feature_limit,
+        polynomial_features=polynomial_features,
+    )
+    return X_limited, y_limited, scope

--- a/tools/tabularlearner/feature_importance.py
+++ b/tools/tabularlearner/feature_importance.py
@@ -5,6 +5,7 @@ import os
 import matplotlib.pyplot as plt
 import pandas as pd
 import shap
+from explainability_limits import limit_explainability_data
 from pycaret.classification import ClassificationExperiment
 from pycaret.regression import RegressionExperiment
 
@@ -25,6 +26,7 @@ class FeatureImportanceAnalyzer:
         max_plot_features=None,
         processed_data=None,
         max_shap_rows=None,
+        polynomial_features=False,
     ):
         self.task_type = task_type
         self.output_dir = output_dir
@@ -33,6 +35,9 @@ class FeatureImportanceAnalyzer:
         self._skip_messages = []
         self.shap_total_features = None
         self.shap_used_features = None
+        self.shap_total_rows = None
+        self.shap_used_rows = None
+        self.shap_scope = None
         if isinstance(max_plot_features, int) and max_plot_features > 0:
             self.max_plot_features = max_plot_features
         elif max_plot_features is None:
@@ -65,6 +70,7 @@ class FeatureImportanceAnalyzer:
 
         self.plots = {}
         self.max_shap_rows = max_shap_rows
+        self.polynomial_features = bool(polynomial_features)
 
     def _get_feature_names_from_model(self, model):
         """Best-effort extraction of feature names seen by the estimator."""
@@ -198,78 +204,29 @@ class FeatureImportanceAnalyzer:
         if X_data is None:
             raise RuntimeError("No transformed dataset found for SHAP.")
 
-        n_rows, n_features = X_data.shape
-        self.shap_total_features = n_features
-        feature_cap = (
-            min(self.max_plot_features, n_features)
-            if self.max_plot_features is not None
-            else n_features
-        )
-        if max_features is None:
-            max_features = feature_cap
-        else:
-            max_features = min(max_features, feature_cap)
-        display_features = list(X_data.columns)
-
-        try:
-            if hasattr(model, "feature_importances_"):
-                importances = pd.Series(
-                    model.feature_importances_, index=X_data.columns
-                )
-                top_features = importances.nlargest(max_features).index
-            elif hasattr(model, "coef_"):
-                coef = abs(model.coef_).flatten()
-                importances = pd.Series(coef, index=X_data.columns)
-                top_features = importances.nlargest(max_features).index
-            else:
-                variances = X_data.var()
-                top_features = variances.nlargest(max_features).index
-
-            candidate_features = list(top_features)
-            missing = [f for f in candidate_features if f not in X_data.columns]
-            display_features = [f for f in candidate_features if f in X_data.columns]
-            if missing:
-                LOG.warning(
-                    "Dropping %s transformed feature(s) not present in SHAP frame: %s",
-                    len(missing),
-                    missing[:5],
-                )
-            if display_features and len(display_features) < n_features:
-                LOG.info(
-                    "Restricting SHAP display to top %s of %s features",
-                    len(display_features),
-                    n_features,
-                )
-            elif not display_features:
-                display_features = list(X_data.columns)
-        except Exception as e:
-            LOG.warning(
-                f"Feature limiting failed: {e}. Using all {n_features} features."
-            )
-            display_features = list(X_data.columns)
-
-        self.shap_used_features = len(display_features)
-
-        # Apply the column restriction so SHAP only runs on the selected features.
-        if display_features:
-            X_data = X_data[display_features]
-            n_rows, n_features = X_data.shape
-
-        # --- Adaptive row subsampling ---
-        if max_samples is None:
-            if n_rows <= 500:
-                max_samples = n_rows
-            elif n_rows <= 5000:
-                max_samples = 500
-            else:
-                max_samples = min(1000, int(n_rows * 0.1))
-
+        row_cap = max_samples
         if self.max_shap_rows is not None:
-            max_samples = min(max_samples, self.max_shap_rows)
-
-        if n_rows > max_samples:
-            LOG.info(f"Subsampling SHAP rows: {max_samples} of {n_rows}")
-            X_data = X_data.sample(max_samples, random_state=42)
+            row_cap = self.max_shap_rows if row_cap is None else min(row_cap, self.max_shap_rows)
+        X_data, _, scope = limit_explainability_data(
+            X_data,
+            model=model,
+            max_features=(
+                self.max_plot_features
+                if max_features is None
+                else min(max_features, self.max_plot_features or max_features)
+            ),
+            max_rows=row_cap,
+            random_seed=42,
+            polynomial_features=self.polynomial_features,
+            context="Custom SHAP",
+        )
+        self.shap_scope = scope
+        self.shap_total_rows = scope.total_rows
+        self.shap_used_rows = scope.used_rows
+        self.shap_total_features = scope.total_features
+        self.shap_used_features = scope.used_features
+        display_features = list(X_data.columns)
+        n_rows, n_features = X_data.shape
 
         # --- Adaptive feature display ---
         display_cap = (

--- a/tools/tabularlearner/pycaret_classification.py
+++ b/tools/tabularlearner/pycaret_classification.py
@@ -137,7 +137,13 @@ class ClassificationModelTrainer(BaseModelTrainer):
             )
 
         X_test = self.exp.X_test_transformed.copy()
-        y_test = self.exp.y_test_transformed
+        y_test = pd.Series(self.exp.y_test_transformed).reset_index(drop=True)
+        X_test, y_test = self._limit_explainer_data(
+            X_test,
+            y_test,
+            context="ClassifierExplainer",
+            cap_features=False,
+        )
         label_encoder = None
         try:
             from pycaret.utils.generic import get_label_encoder
@@ -277,23 +283,33 @@ class ClassificationModelTrainer(BaseModelTrainer):
             except Exception as e:
                 LOG.error(f"Error generating explainer plot {key}: {e}")
 
-        # mean SHAP importances
-        try:
-            self.explainer_plots["shap_mean"] = explainer.plot_importances()
-        except Exception as e:
-            LOG.warning(f"Could not generate shap_mean: {e}")
-
-        # permutation importances
-        try:
-            self.explainer_plots["shap_perm"] = lambda: explainer.plot_importances(
-                kind="permutation"
+        if self._explainer_feature_count_exceeds_cap():
+            LOG.info(
+                "Skipping ExplainerDashboard SHAP/permutation importance because "
+                "the transformed test set has %s features; custom SHAP remains capped "
+                "to top %s features.",
+                self.explainer_scope.total_features,
+                self.explainer_scope.feature_cap,
             )
-        except Exception as e:
-            LOG.warning(f"Could not generate shap_perm: {e}")
+            self.explainer_dashboard_importance_skipped = True
+        else:
+            # mean SHAP importances
+            try:
+                self.explainer_plots["shap_mean"] = explainer.plot_importances()
+            except Exception as e:
+                LOG.warning(f"Could not generate shap_mean: {e}")
+
+            # permutation importances
+            try:
+                self.explainer_plots["shap_perm"] = lambda: explainer.plot_importances(
+                    kind="permutation"
+                )
+            except Exception as e:
+                LOG.warning(f"Could not generate shap_perm: {e}")
 
         # PDPs for each feature (appended last)
         valid_feats = []
-        for feat in self.features_name:
+        for feat in self.plot_feature_names:
             if feat in explainer.X.columns or feat in explainer.onehot_cols:
                 valid_feats.append(feat)
             else:

--- a/tools/tabularlearner/pycaret_macros.xml
+++ b/tools/tabularlearner/pycaret_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TABULAR_LEARNER_VERSION@">0.1.4</token>
+    <token name="@TABULAR_LEARNER_VERSION@">0.1.5</token>
     <token name="@PYCARET_VERSION@">3.3.2</token>
     <token name="@SUFFIX@">2</token>
     <token name="@PYCARET_PREDICT_VERSION@">@PYCARET_VERSION@+@SUFFIX@</token>

--- a/tools/tabularlearner/pycaret_regression.py
+++ b/tools/tabularlearner/pycaret_regression.py
@@ -1,5 +1,6 @@
 import logging
 
+import pandas as pd
 from base_model_trainer import BaseModelTrainer
 from dashboard import generate_regression_explainer_dashboard
 from pycaret.regression import RegressionExperiment
@@ -65,7 +66,13 @@ class RegressionModelTrainer(BaseModelTrainer):
         from explainerdashboard import RegressionExplainer
 
         X_test = self.exp.X_test_transformed.copy()
-        y_test = self.exp.y_test_transformed
+        y_test = pd.Series(self.exp.y_test_transformed).reset_index(drop=True)
+        X_test, y_test = self._limit_explainer_data(
+            X_test,
+            y_test,
+            context="RegressionExplainer",
+            cap_features=False,
+        )
 
         try:
             explainer = RegressionExplainer(self.best_model, X_test, y_test)
@@ -73,23 +80,33 @@ class RegressionModelTrainer(BaseModelTrainer):
             LOG.error(f"Error creating explainer: {e}")
             return
 
-        # --- 1) SHAP mean impact (average absolute SHAP values) ---
-        try:
-            self.explainer_plots["shap_mean"] = explainer.plot_importances()
-        except Exception as e:
-            LOG.error(f"Error generating SHAP mean importance: {e}")
-
-        # --- 2) SHAP permutation importance ---
-        try:
-            self.explainer_plots["shap_perm"] = explainer.plot_importances_permutation(
-                kind="permutation"
+        if self._explainer_feature_count_exceeds_cap():
+            LOG.info(
+                "Skipping ExplainerDashboard SHAP/permutation importance because "
+                "the transformed test set has %s features; custom SHAP remains capped "
+                "to top %s features.",
+                self.explainer_scope.total_features,
+                self.explainer_scope.feature_cap,
             )
-        except Exception as e:
-            LOG.error(f"Error generating SHAP permutation importance: {e}")
+            self.explainer_dashboard_importance_skipped = True
+        else:
+            # --- 1) SHAP mean impact (average absolute SHAP values) ---
+            try:
+                self.explainer_plots["shap_mean"] = explainer.plot_importances()
+            except Exception as e:
+                LOG.error(f"Error generating SHAP mean importance: {e}")
+
+            # --- 2) SHAP permutation importance ---
+            try:
+                self.explainer_plots["shap_perm"] = explainer.plot_importances_permutation(
+                    kind="permutation"
+                )
+            except Exception as e:
+                LOG.error(f"Error generating SHAP permutation importance: {e}")
 
         # Pre-filter features so we never call PDP or residual-vs-feature on missing cols
         valid_feats = []
-        for feat in self.features_name:
+        for feat in self.plot_feature_names:
             if feat in explainer.X.columns or feat in explainer.onehot_cols:
                 valid_feats.append(feat)
             else:


### PR DESCRIPTION
# Description

This PR adds shared row and feature caps for Tabular Learner explainability/report-generation paths.

The goal is to prevent users from waiting a long time after model training finishes because SHAP, permutation importance, PDP, or ExplainerDashboard feature-importance plots are running on large transformed datasets.

Training, model selection, final metrics, and the saved model are unchanged. The caps only affect feature-importance and explainability plots in the generated report.

# Problem

The custom feature-importance path already had some caps:

- Feature importance plots default to top 30 features.
- SHAP is restricted to selected top features.
- SHAP rows are adaptively sampled:
  - `<=500 rows`: all rows
  - `501-5000 rows`: 500 rows
  - `>5000 rows`: `min(1000, 10% of rows)`

Polynomial features tighten this to:

- top 15 features
- max 200 SHAP rows

However, the separate ExplainerDashboard path could still generate SHAP/permutation importance on the full transformed test set.

On datasets with many transformed features, users could still wait a long time during report generation even though the custom SHAP path was capped.

# What Changed

- Added shared explainability cap logic in `explainability_limits.py`.
- Refactored custom SHAP to use the shared cap policy.
- Applied the same row cap policy to ExplainerDashboard inputs.
- Preserved full transformed columns for ExplainerDashboard model compatibility.
- Skip ExplainerDashboard SHAP/permutation importance when transformed feature count exceeds the feature cap.
- Continue showing custom capped SHAP in that case.
- Limit PDP and residual-vs-feature plots to the selected plot features instead of all features.
- Add report metadata showing exactly what was capped.

# Cap Policy

## Default Explainability Feature Cap

- top 30 transformed features

## Default Explainability Row Cap

- `<=500 rows`: use all rows
- `501-5000 rows`: use 500 rows
- `>5000 rows`: use `min(1000, 10% of rows)`

## Polynomial Feature Mode

- top 15 transformed features
- max 200 rows

# Important Implementation Detail

For custom SHAP, columns can be restricted before calculation because that code controls the SHAP input directly.

For ExplainerDashboard, columns are **not** dropped before constructing the explainer because the trained model expects the full transformed feature matrix. Dropping columns there could break prediction.

Instead:

- rows are capped before creating the ExplainerDashboard explainer
- feature-heavy dashboard SHAP/permutation importance is skipped when feature count exceeds the cap
- the report uses the custom capped SHAP path for feature-level interpretation
- PDP/residual-vs-feature plots are limited to selected feature names

# Report Changes

The Feature Importance section now includes a **Feature Importance Scope** table showing:

- Custom SHAP rows used vs total rows
- Custom SHAP transformed features used vs total transformed features
- ExplainerDashboard rows used vs total rows
- ExplainerDashboard transformed features used vs total transformed features
- whether ExplainerDashboard SHAP/permutation importance was skipped
- whether polynomial feature caps were applied

A report note explains that explainability plots may be computed on capped subsets to keep report generation responsive.

# Why

This keeps the report informative while avoiding cases where users wait tens of minutes after model training solely for feature-importance plots.

The highest-risk expensive paths are now bounded, and users can see exactly what data scope was used for interpretation.