### PR TITLE
Fix Tabular Learner multiclass metrics, SHAP reports, and non-fatal tree plotting

### DIFF
--- a/tools/multimodallearner/multimodal_learner.xml
+++ b/tools/multimodallearner/multimodal_learner.xml
@@ -15,6 +15,7 @@
     <include path="plot_logic.py"/>
     <include path="report_utils.py"/>
     <include path="feature_help_modal.py"/>
+    <include path="feature_importance.py"/>
   </required_files>
 
   <stdio>

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -7,17 +7,19 @@ import h5py
 import joblib
 import numpy as np
 import pandas as pd
+from classification_metrics import (
+    labels_in_sample_order,
+    weighted_ovr_pr_auc as _weighted_ovr_pr_auc,
+)
 from explainability_limits import limit_explainability_data
 from feature_help_modal import get_feature_metrics_help_modal
 from feature_importance import FeatureImportanceAnalyzer
 from sklearn.metrics import (
     accuracy_score,
-    auc,
     cohen_kappa_score,
     confusion_matrix,
     f1_score,
     matthews_corrcoef,
-    precision_recall_curve,
     precision_score,
     recall_score,
     roc_auc_score,
@@ -33,73 +35,6 @@ from utils import (
 
 logging.basicConfig(level=logging.DEBUG)
 LOG = logging.getLogger(__name__)
-
-
-def _weighted_ovr_pr_auc(y_true, y_score, labels=None):
-    """
-    Compute PR-AUC from precision-recall curves.
-
-    Binary tasks use the positive-class probability curve. Multiclass tasks use
-    one-vs-rest curves per class and return a support-weighted mean.
-    """
-    y_true_series = pd.Series(y_true).reset_index(drop=True)
-    if labels is not None:
-        class_labels = list(labels)
-    else:
-        class_labels = list(pd.unique(y_true_series))
-        try:
-            class_labels = sorted(class_labels)
-        except Exception:
-            pass
-    if len(class_labels) < 2:
-        return np.nan
-
-    scores = np.asarray(y_score)
-    if len(scores) != len(y_true_series):
-        return np.nan
-
-    if len(class_labels) == 2:
-        try:
-            pos_label = 1 if 1 in class_labels else sorted(class_labels)[-1]
-        except Exception:
-            pos_label = class_labels[-1]
-        if scores.ndim == 2:
-            if scores.shape[1] < 2:
-                scores = scores.ravel()
-            else:
-                try:
-                    pos_idx = class_labels.index(pos_label)
-                except ValueError:
-                    pos_idx = scores.shape[1] - 1
-                pos_idx = min(pos_idx, scores.shape[1] - 1)
-                scores = scores[:, pos_idx]
-        precision, recall, _ = precision_recall_curve(
-            (y_true_series == pos_label).astype(int),
-            scores,
-        )
-        return auc(recall, precision)
-
-    if scores.ndim != 2 or scores.shape[1] < len(class_labels):
-        return np.nan
-
-    weighted_total = 0.0
-    support_total = 0
-    for class_idx, class_label in enumerate(class_labels):
-        if class_idx >= scores.shape[1]:
-            break
-        y_true_bin = (y_true_series == class_label).astype(int)
-        if len(pd.unique(y_true_bin)) < 2:
-            continue
-        precision, recall, _ = precision_recall_curve(
-            y_true_bin,
-            scores[:, class_idx],
-        )
-        support = int(y_true_bin.sum())
-        weighted_total += auc(recall, precision) * support
-        support_total += support
-
-    return weighted_total / support_total if support_total else np.nan
-
 
 def pr_auc_curve_score(y_true, y_score):
     """
@@ -1094,7 +1029,6 @@ class BaseModelTrainer:
             rows.append(row)
 
         df = pd.DataFrame(rows, columns=["Label", *split_map.keys()])
-        df.sort_values("Label", inplace=True)
 
         note = (
             "<p class='report-footnote'>Note: The Training / CV Pool column "
@@ -1381,11 +1315,7 @@ class BaseModelTrainer:
         label_values = []
         if self.task_type == "classification":
             y_display_series = self._decode_class_labels_for_display(y_display_series)
-            label_values = pd.unique(y_display_series)
-            try:
-                label_values = sorted(label_values, key=lambda item: str(item))
-            except Exception:
-                label_values = list(label_values)
+            label_values = labels_in_sample_order(y_display_series)
 
         def _format_label_counts(indices):
             if self.task_type != "classification":
@@ -1798,7 +1728,11 @@ class BaseModelTrainer:
         y_true = preds["y_true"]
         classes = preds.get("classes")
         try:
-            pr_auc = _weighted_ovr_pr_auc(y_true, y_scores, labels=classes)
+            pr_auc = _weighted_ovr_pr_auc(
+                y_true,
+                y_scores,
+                labels=classes if classes else None,
+            )
             if np.isnan(pr_auc):
                 return None
             return pr_auc

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -107,6 +107,30 @@ def pr_auc_curve_score(y_true, y_score):
     return _weighted_ovr_pr_auc(y_true, y_score)
 
 
+def _add_pr_auc_metric_if_supported(exp):
+    """
+    Register PyCaret's custom PR-AUC metric only for binary classification.
+
+    PyCaret 3.3.2 can pass multiclass probability matrices through a
+    single-column prediction-score path during predict_model(), which raises
+    a DataFrame shape error. Multiclass PR-AUC is still computed later by the
+    report code from the model's probability matrix.
+    """
+    if getattr(exp, "is_multiclass", False):
+        LOG.info(
+            "Skipping PyCaret custom PR-AUC metric for multiclass "
+            "classification; report PR-AUC will be computed separately."
+        )
+        return False
+    exp.add_metric(
+        id="PR-AUC",
+        name="PR-AUC",
+        target="pred_proba",
+        score_func=pr_auc_curve_score,
+    )
+    return True
+
+
 class BaseModelTrainer:
     def __init__(
         self,
@@ -733,11 +757,8 @@ class BaseModelTrainer:
     def train_model(self):
         LOG.info("Training and selecting the best model")
         if self.task_type == "classification":
-            self.exp.add_metric(
-                id="PR-AUC",
-                name="PR-AUC",
-                target="pred_proba",
-                score_func=pr_auc_curve_score,
+            self._pycaret_pr_auc_metric_added = _add_pr_auc_metric_if_supported(
+                self.exp
             )
         # Build arguments for compare_models()
         compare_kwargs = {}
@@ -754,6 +775,17 @@ class BaseModelTrainer:
 
         best_metric = getattr(self, "best_model_metric", None)
         if best_metric:
+            if (
+                self.task_type == "classification"
+                and best_metric == "PR-AUC"
+                and not getattr(self, "_pycaret_pr_auc_metric_added", False)
+            ):
+                LOG.warning(
+                    "PR-AUC model ranking is not supported for multiclass "
+                    "classification in this PyCaret path; ranking models by "
+                    "ROC-AUC instead."
+                )
+                best_metric = "AUC"
             compare_kwargs["sort"] = best_metric
             self._best_model_metric_used = best_metric
             LOG.info(f"Ranking models using metric: {best_metric}")
@@ -1716,22 +1748,17 @@ class BaseModelTrainer:
 
     def _replace_test_pr_auc(self):
         """
-        Replace PyCaret's custom PR-AUC output with the report's curve-based
-        PR-AUC for the held-out test split.
+        Add or replace PyCaret's custom PR-AUC output with the report's
+        curve-based PR-AUC for the held-out test split.
         """
         if not isinstance(self.test_result_df, pd.DataFrame):
-            return
-        if (
-            "PR-AUC" not in self.test_result_df.columns
-            and "PR-AUC-Weighted" not in self.test_result_df.columns
-        ):
             return
 
         preds = self._get_test_predictions_for_report()
         pr_auc = self._compute_pr_auc_from_predictions(preds)
         if pr_auc is None:
             LOG.warning(
-                "Could not replace PR-AUC-Weighted; test PR-AUC was unavailable."
+                "Could not add or replace PR-AUC; test PR-AUC was unavailable."
             )
             return
 

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -904,6 +904,15 @@ class BaseModelTrainer:
                 return arr
 
             encoded_vals = flat[mask]
+            original_classes = set(getattr(label_encoder, "classes_", []))
+            if original_classes:
+                try:
+                    value_set = set(encoded_vals)
+                    encoded_range = set(range(len(original_classes)))
+                    if value_set.issubset(original_classes) and not value_set.issubset(encoded_range):
+                        return arr
+                except Exception:
+                    pass
             try:
                 decoded_vals = label_encoder.inverse_transform(encoded_vals)
             except Exception:

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -13,6 +13,7 @@ from feature_importance import FeatureImportanceAnalyzer
 from sklearn.metrics import (
     accuracy_score,
     auc,
+    cohen_kappa_score,
     confusion_matrix,
     f1_score,
     matthews_corrcoef,
@@ -820,17 +821,7 @@ class BaseModelTrainer:
                 columns={"PR-AUC-Weighted": "PR-AUC"}, inplace=True
             )
 
-        prob_thresh = getattr(self, "probability_threshold", None)
-        if self.task_type == "classification" and (
-            prob_thresh is not None
-        ):
-            _ = self.exp.predict_model(
-                self.best_model, probability_threshold=prob_thresh
-            )
-        else:
-            _ = self.exp.predict_model(self.best_model)
-
-        self.test_result_df = self.exp.pull()
+        self._collect_test_results_from_pycaret()
         if self.task_type == "classification":
             self.test_result_df.rename(
                 columns={"AUC": "ROC-AUC"}, inplace=True
@@ -839,6 +830,73 @@ class BaseModelTrainer:
                 columns={"PR-AUC-Weighted": "PR-AUC"}, inplace=True
             )
             self._replace_test_pr_auc()
+
+    def _collect_test_results_from_pycaret(self):
+        """
+        Collect PyCaret's held-out metric table, falling back to local metric
+        computation when PyCaret's multiclass predict_model path fails while
+        constructing its prediction DataFrame.
+        """
+        prob_thresh = getattr(self, "probability_threshold", None)
+        is_multiclass = (
+            self.task_type == "classification"
+            and getattr(self.exp, "is_multiclass", False)
+        )
+        predict_kwargs = {}
+        if (
+            self.task_type == "classification"
+            and prob_thresh is not None
+            and not is_multiclass
+        ):
+            predict_kwargs["probability_threshold"] = prob_thresh
+
+        try:
+            _ = self.exp.predict_model(self.best_model, **predict_kwargs)
+            self.test_result_df = self.exp.pull()
+            return
+        except ValueError as exc:
+            if not (
+                is_multiclass
+                and "Shape of passed values" in str(exc)
+                and "indices imply" in str(exc)
+            ):
+                raise
+            LOG.warning(
+                "PyCaret predict_model failed on multiclass prediction shape; "
+                "using GLEAM-computed held-out test metrics instead: %s",
+                exc,
+            )
+
+        self.test_result_df = self._build_fallback_test_result_df()
+
+    def _build_fallback_test_result_df(self):
+        """
+        Build a one-row held-out test metric table without PyCaret predict_model.
+        This is used only when PyCaret cannot format multiclass predictions.
+        """
+        preds = self._get_test_predictions_for_report()
+        if preds is None:
+            LOG.warning(
+                "Could not compute fallback held-out test metrics; no test "
+                "prediction bundle was available."
+            )
+            return pd.DataFrame()
+
+        metric_columns = [
+            ("Accuracy", "Accuracy"),
+            ("ROC-AUC", "ROC-AUC"),
+            ("Precision", "Prec."),
+            ("Recall", "Recall"),
+            ("F1-Score", "F1"),
+            ("PR-AUC", "PR-AUC"),
+            ("Kappa", "Kappa"),
+            ("MCC", "MCC"),
+        ]
+        row = {}
+        for metric_name, column_name in metric_columns:
+            value = self._compute_metric_value(metric_name, preds, "Test")
+            row[column_name] = value if value is not None else np.nan
+        return pd.DataFrame([row])
 
     def save_model(self):
         hdf5_path = Path(self.output_dir) / "pycaret_model.h5"
@@ -1691,6 +1749,8 @@ class BaseModelTrainer:
                     )
             if metric_name == "PR-AUC":
                 return self._compute_pr_auc_from_predictions(preds)
+            if metric_name == "Kappa":
+                return cohen_kappa_score(y_true, y_pred)
             if metric_name == "Specificity":
                 labels = pd.unique(pd.concat([y_true, y_pred], ignore_index=True))
                 if len(labels) != 2:

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -2533,6 +2533,9 @@ class BaseModelTrainer:
         self.save_model()
         self.generate_plots()
         self.generate_plots_explainer()
-        self.generate_tree_plots()
+        try:
+            self.generate_tree_plots()
+        except Exception as exc:
+            LOG.warning("Tree plots skipped: %s", exc)
         self.save_html_report()
         # self.save_dashboard()

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -36,6 +36,7 @@ from utils import (
 logging.basicConfig(level=logging.DEBUG)
 LOG = logging.getLogger(__name__)
 
+
 def pr_auc_curve_score(y_true, y_score):
     """
     PR-AUC scorer matching the report's Precision-Recall curve logic.

--- a/tools/tabularlearner/classification_metrics.py
+++ b/tools/tabularlearner/classification_metrics.py
@@ -1,0 +1,110 @@
+import numpy as np
+import pandas as pd
+from sklearn.metrics import auc, precision_recall_curve
+
+
+def labels_in_sample_order(*values):
+    """Return labels in first-seen sample order across one or more arrays."""
+    series = [
+        pd.Series(value).reset_index(drop=True)
+        for value in values
+        if value is not None
+    ]
+    if not series:
+        return []
+    return pd.unique(pd.concat(series, ignore_index=True)).tolist()
+
+
+def labels_in_metric_order(values):
+    """Return labels in deterministic metric order when probability order is unknown."""
+    labels = labels_in_sample_order(values)
+    try:
+        return sorted(labels)
+    except Exception:
+        return labels
+
+
+def positive_class_label(labels):
+    labels = [] if labels is None else list(labels)
+    if not labels:
+        return 1
+    return 1 if 1 in labels else labels[-1]
+
+
+def probability_class_labels(y_true, y_score, model_classes=None):
+    """
+    Resolve the class label represented by each probability column.
+
+    scikit-learn probability columns follow estimator.classes_. If that is
+    unavailable, fall back to first-seen labels only when the count matches.
+    """
+    scores = np.asarray(y_score)
+    classes = [] if model_classes is None else list(model_classes)
+    if scores.ndim == 2 and classes and len(classes) == scores.shape[1]:
+        return classes
+
+    sample_labels = labels_in_sample_order(y_true)
+    if scores.ndim == 2 and len(sample_labels) == scores.shape[1]:
+        return sample_labels
+    if scores.ndim == 1 and len(classes) >= 2:
+        return classes
+    return classes or sample_labels
+
+
+def weighted_ovr_pr_auc(y_true, y_score, labels=None, pos_label=None):
+    """
+    Compute curve-based PR-AUC.
+
+    Binary tasks use one positive-class curve. Multiclass tasks use one-vs-rest
+    curves in probability-column order and return a support-weighted mean.
+    """
+    y_true_series = pd.Series(y_true).reset_index(drop=True)
+    class_labels = (
+        list(labels) if labels is not None else labels_in_metric_order(y_true_series)
+    )
+    if len(class_labels) < 2:
+        return np.nan
+
+    scores = np.asarray(y_score)
+    if len(scores) != len(y_true_series):
+        return np.nan
+
+    if len(class_labels) == 2:
+        pos_label = (
+            pos_label
+            if pos_label is not None
+            else positive_class_label(class_labels)
+        )
+        if scores.ndim == 2:
+            if scores.shape[1] < 2:
+                scores = scores.ravel()
+            else:
+                try:
+                    pos_idx = class_labels.index(pos_label)
+                except ValueError:
+                    pos_idx = scores.shape[1] - 1
+                scores = scores[:, min(pos_idx, scores.shape[1] - 1)]
+        precision, recall, _ = precision_recall_curve(
+            (y_true_series == pos_label).astype(int),
+            scores,
+        )
+        return auc(recall, precision)
+
+    if scores.ndim != 2 or scores.shape[1] != len(class_labels):
+        return np.nan
+
+    weighted_total = 0.0
+    support_total = 0
+    for class_idx, class_label in enumerate(class_labels):
+        y_true_bin = (y_true_series == class_label).astype(int)
+        if len(pd.unique(y_true_bin)) < 2:
+            continue
+        precision, recall, _ = precision_recall_curve(
+            y_true_bin,
+            scores[:, class_idx],
+        )
+        support = int(y_true_bin.sum())
+        weighted_total += auc(recall, precision) * support
+        support_total += support
+
+    return weighted_total / support_total if support_total else np.nan

--- a/tools/tabularlearner/feature_importance.py
+++ b/tools/tabularlearner/feature_importance.py
@@ -48,9 +48,15 @@ class FeatureImportanceAnalyzer:
             self.max_plot_features = None
 
         if exp is not None:
-            # Assume all configs (data, target) are in exp
-            self.data = exp.dataset.copy()
-            self.target = exp.target_param
+            # Prefer explicit data from the trainer. Some PyCaret versions
+            # mutate exp.dataset after setup when imbalance handling is enabled.
+            self.target = getattr(exp, "target_param", None)
+            if processed_data is not None:
+                self.data = processed_data.copy()
+            elif data is not None:
+                self.data = data.copy()
+            else:
+                self.data = exp.dataset.copy()
             LOG.info("Using provided experiment object")
         else:
             if data is not None:
@@ -67,7 +73,9 @@ class FeatureImportanceAnalyzer:
                 if task_type == "classification"
                 else RegressionExperiment()
             )
-        if processed_data is not None:
+        if self.target is None and target_col is not None:
+            self.target = self.data.columns[int(target_col) - 1]
+        if exp is None and processed_data is not None:
             self.data = processed_data
 
         self.plots = {}
@@ -90,6 +98,24 @@ class FeatureImportanceAnalyzer:
             if names is not None:
                 return list(names)
         return None
+
+    def _experiment_is_setup(self):
+        if self.exp is None:
+            return False
+
+        is_setup = getattr(self.exp, "is_setup", None)
+        if is_setup is not None:
+            return bool(is_setup)
+
+        for key in ("X_test_transformed", "X_train_transformed", "X_transformed"):
+            try:
+                value = self.exp.get_config(key)
+            except Exception:
+                value = getattr(self.exp, key, None)
+            if value is not None:
+                return True
+
+        return False
 
     def _get_transformed_frame(self, model=None, prefer_test=True):
         """Return a DataFrame that mirrors the matrix fed to the estimator."""
@@ -119,7 +145,7 @@ class FeatureImportanceAnalyzer:
         return None
 
     def setup_pycaret(self):
-        if self.exp is not None and hasattr(self.exp, "is_setup") and self.exp.is_setup:
+        if self._experiment_is_setup():
             LOG.info("Experiment already set up. Skipping PyCaret setup.")
             return
         LOG.info("Initializing PyCaret")
@@ -674,11 +700,7 @@ class FeatureImportanceAnalyzer:
         return _permutation(predict_fn), "permutation-default", False
 
     def run(self):
-        if (
-            self.exp is None
-            or not hasattr(self.exp, "is_setup")
-            or not self.exp.is_setup
-        ):
+        if not self._experiment_is_setup():
             self.setup_pycaret()
         self.save_tree_importance()
         self.save_shap_values()

--- a/tools/tabularlearner/feature_importance.py
+++ b/tools/tabularlearner/feature_importance.py
@@ -12,6 +12,7 @@ from pycaret.regression import RegressionExperiment
 
 logging.basicConfig(level=logging.DEBUG)
 LOG = logging.getLogger(__name__)
+logging.getLogger("matplotlib").setLevel(logging.WARNING)
 logging.getLogger("matplotlib.font_manager").setLevel(logging.ERROR)
 
 

--- a/tools/tabularlearner/feature_importance.py
+++ b/tools/tabularlearner/feature_importance.py
@@ -12,6 +12,7 @@ from pycaret.regression import RegressionExperiment
 
 logging.basicConfig(level=logging.DEBUG)
 LOG = logging.getLogger(__name__)
+logging.getLogger("matplotlib.font_manager").setLevel(logging.ERROR)
 
 
 class FeatureImportanceAnalyzer:
@@ -298,11 +299,10 @@ class FeatureImportanceAnalyzer:
                     error_message,
                 )
                 try:
-                    explainer = shap.TreeExplainer(
+                    explainer = self._tree_explainer(
                         model,
                         bg,
                         feature_perturbation="interventional",
-                        n_jobs=-1,
                     )
                     shap_values = explainer(X_data)
                     self.shap_model_name = (
@@ -445,6 +445,9 @@ class FeatureImportanceAnalyzer:
             return model.decision_function
         return model.predict
 
+    def _tree_explainer(self, model, background, **kwargs):
+        return shap.TreeExplainer(model, background, **kwargs)
+
     @staticmethod
     def _safe_label(label):
         return (
@@ -507,8 +510,8 @@ class FeatureImportanceAnalyzer:
             # 4) Random Forest
             if "randomforestclassifier" in lname:
                 return (
-                    shap.TreeExplainer(
-                        model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
+                    self._tree_explainer(
+                        model, bg, feature_perturbation="tree_path_dependent"
                     ),
                     "tree_path_dependent",
                     True,
@@ -517,8 +520,8 @@ class FeatureImportanceAnalyzer:
             # 5) Gradient Boosting
             if "gradientboostingclassifier" in lname:
                 return (
-                    shap.TreeExplainer(
-                        model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
+                    self._tree_explainer(
+                        model, bg, feature_perturbation="tree_path_dependent"
                     ),
                     "tree_path_dependent",
                     True,
@@ -527,8 +530,8 @@ class FeatureImportanceAnalyzer:
             # 6) AdaBoost
             if "adaboostclassifier" in lname:
                 return (
-                    shap.TreeExplainer(
-                        model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
+                    self._tree_explainer(
+                        model, bg, feature_perturbation="tree_path_dependent"
                     ),
                     "tree_path_dependent",
                     True,
@@ -537,8 +540,8 @@ class FeatureImportanceAnalyzer:
             # 7) Extra Trees
             if "extratreesclassifier" in lname:
                 return (
-                    shap.TreeExplainer(
-                        model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
+                    self._tree_explainer(
+                        model, bg, feature_perturbation="tree_path_dependent"
                     ),
                     "tree_path_dependent",
                     True,
@@ -547,12 +550,11 @@ class FeatureImportanceAnalyzer:
             # 8) LightGBM
             if "lgbmclassifier" in lname:
                 return (
-                    shap.TreeExplainer(
+                    self._tree_explainer(
                         model,
                         bg,
                         model_output="raw",
                         feature_perturbation="tree_path_dependent",
-                        n_jobs=-1,
                     ),
                     "tree_path_dependent",
                     True,
@@ -561,8 +563,8 @@ class FeatureImportanceAnalyzer:
             # 9) XGBoost
             if "xgbclassifier" in lname:
                 return (
-                    shap.TreeExplainer(
-                        model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
+                    self._tree_explainer(
+                        model, bg, feature_perturbation="tree_path_dependent"
                     ),
                     "tree_path_dependent",
                     True,
@@ -571,8 +573,8 @@ class FeatureImportanceAnalyzer:
             # 10) CatBoost (classifier)
             if "catboost" in lname:
                 return (
-                    shap.TreeExplainer(
-                        model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
+                    self._tree_explainer(
+                        model, bg, feature_perturbation="tree_path_dependent"
                     ),
                     "tree_path_dependent",
                     True,
@@ -592,8 +594,8 @@ class FeatureImportanceAnalyzer:
             # 13) Decision Tree
             if "decisiontreeclassifier" in lname:
                 return (
-                    shap.TreeExplainer(
-                        model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
+                    self._tree_explainer(
+                        model, bg, feature_perturbation="tree_path_dependent"
                     ),
                     "tree_path_dependent",
                     True,
@@ -659,8 +661,8 @@ class FeatureImportanceAnalyzer:
         ]
         if any(k in lname for k in tree_class_names):
             return (
-                shap.TreeExplainer(
-                    model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
+                self._tree_explainer(
+                    model, bg, feature_perturbation="tree_path_dependent"
                 ),
                 "tree_path_dependent",
                 True,
@@ -669,28 +671,27 @@ class FeatureImportanceAnalyzer:
         # Boosting libraries
         if "lgbmregressor" in lname or "lightgbm" in lname:
             return (
-                shap.TreeExplainer(
+                self._tree_explainer(
                     model,
                     bg,
                     model_output="raw",
                     feature_perturbation="tree_path_dependent",
-                    n_jobs=-1,
                 ),
                 "tree_path_dependent",
                 True,
             )
         if "xgbregressor" in lname or "xgboost" in lname:
             return (
-                shap.TreeExplainer(
-                    model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
+                self._tree_explainer(
+                    model, bg, feature_perturbation="tree_path_dependent"
                 ),
                 "tree_path_dependent",
                 True,
             )
         if "catboost" in lname:
             return (
-                shap.TreeExplainer(
-                    model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
+                self._tree_explainer(
+                    model, bg, feature_perturbation="tree_path_dependent"
                 ),
                 "tree_path_dependent",
                 True,

--- a/tools/tabularlearner/feature_importance.py
+++ b/tools/tabularlearner/feature_importance.py
@@ -5,6 +5,7 @@ import os
 import matplotlib.pyplot as plt
 import pandas as pd
 import shap
+from classification_metrics import positive_class_label
 from explainability_limits import limit_explainability_data
 from pycaret.classification import ClassificationExperiment
 from pycaret.regression import RegressionExperiment
@@ -38,6 +39,7 @@ class FeatureImportanceAnalyzer:
         self.shap_total_rows = None
         self.shap_used_rows = None
         self.shap_scope = None
+        self.plot_titles = {}
         if isinstance(max_plot_features, int) and max_plot_features > 0:
             self.max_plot_features = max_plot_features
         elif max_plot_features is None:
@@ -196,6 +198,7 @@ class FeatureImportanceAnalyzer:
         plt.savefig(plot_path, bbox_inches="tight")
         plt.close()
         self.plots["tree_importance"] = plot_path
+        self.plot_titles["tree_importance"] = f"Feature importance from {model_type}"
 
     def save_shap_values(self, max_samples=None, max_display=None, max_features=None):
         model = self.best_model or self.exp.get_config("best_model")
@@ -210,14 +213,11 @@ class FeatureImportanceAnalyzer:
         X_data, _, scope = limit_explainability_data(
             X_data,
             model=model,
-            max_features=(
-                self.max_plot_features
-                if max_features is None
-                else min(max_features, self.max_plot_features or max_features)
-            ),
+            max_features=self.max_plot_features,
             max_rows=row_cap,
             random_seed=42,
             polynomial_features=self.polynomial_features,
+            cap_features=False,
             context="Custom SHAP",
         )
         self.shap_scope = scope
@@ -228,7 +228,6 @@ class FeatureImportanceAnalyzer:
         display_features = list(X_data.columns)
         n_rows, n_features = X_data.shape
 
-        # --- Adaptive feature display ---
         display_cap = (
             min(self.max_plot_features, len(display_features))
             if self.max_plot_features is not None
@@ -316,33 +315,23 @@ class FeatureImportanceAnalyzer:
                 self.shap_model_name = None
                 return
 
-        def _limit_explanation_features(explanation):
-            if len(display_features) >= n_features:
-                return explanation
-            try:
-                limited = explanation[:, display_features]
-                LOG.info(
-                    "SHAP explanation trimmed to %s display features.",
-                    len(display_features),
-                )
-                return limited
-            except Exception as exc:
-                LOG.warning(
-                    "Failed to restrict SHAP explanation to top features "
-                    "(sample=%s); plot will include all features. Error: %s",
-                    display_features[:5],
-                    exc,
-                )
-                # Keep using full feature list if trimming fails
-                return explanation
-
         shap_shape = getattr(shap_values, "shape", None)
         class_labels = list(getattr(model, "classes_", []))
         shap_outputs = []
         if shap_shape is not None and len(shap_shape) == 3:
             output_count = shap_shape[2]
             LOG.info("Detected multi-output SHAP explanation with %s classes.", output_count)
-            for class_idx in range(output_count):
+            output_indices = list(range(output_count))
+            if self.task_type == "classification" and output_count == 2:
+                pos_label = positive_class_label(class_labels)
+                try:
+                    output_indices = [class_labels.index(pos_label)]
+                except ValueError:
+                    output_indices = [1]
+                LOG.info(
+                    "Binary SHAP explanation detected; plotting positive class only."
+                )
+            for class_idx in output_indices:
                 try:
                     class_expl = shap_values[..., class_idx]
                 except Exception as exc:
@@ -357,7 +346,9 @@ class FeatureImportanceAnalyzer:
                     if class_labels and class_idx < len(class_labels)
                     else class_idx
                 )
-                shap_outputs.append((class_idx, label, class_expl))
+                shap_outputs.append(
+                    (class_idx, self._class_label_for_display(label), class_expl)
+                )
         else:
             shap_outputs.append((None, None, shap_values))
 
@@ -368,17 +359,16 @@ class FeatureImportanceAnalyzer:
 
         # --- Plot SHAP summary (one per class if needed) ---
         for class_idx, class_label, class_expl in shap_outputs:
-            expl_to_plot = _limit_explanation_features(class_expl)
             suffix = ""
             plot_key = "shap_summary"
             if class_idx is not None:
-                safe_label = str(class_label).replace("/", "_").replace(" ", "_")
+                safe_label = self._safe_label(class_label)
                 suffix = f"_class_{safe_label}"
                 plot_key = f"shap_summary_class_{safe_label}"
             out_filename = f"shap_summary{suffix}.png"
             out_path = os.path.join(self.output_dir, out_filename)
             plt.figure()
-            shap.plots.beeswarm(expl_to_plot, max_display=max_display, show=False)
+            shap.plots.beeswarm(class_expl, max_display=max_display, show=False)
             title = f"SHAP Summary for {model.__class__.__name__}"
             if class_idx is not None:
                 title += f" (class {class_label})"
@@ -387,6 +377,7 @@ class FeatureImportanceAnalyzer:
             plt.savefig(out_path, bbox_inches="tight")
             plt.close()
             self.plots[plot_key] = out_path
+            self.plot_titles[plot_key] = f"{title} (top {max_display} features)"
 
         # --- Log summary ---
         LOG.info(
@@ -407,22 +398,7 @@ class FeatureImportanceAnalyzer:
             ):
                 continue
             encoded_image = self.encode_image_to_base64(plot_path)
-            if plot_name == "tree_importance" and getattr(
-                self, "tree_model_name", None
-            ):
-                section_title = f"Feature importance from {self.tree_model_name}"
-            elif plot_name == "shap_summary":
-                section_title = (
-                    f"SHAP Summary from {getattr(self, 'shap_model_name', 'model')}"
-                )
-            elif plot_name.startswith("shap_summary_class_"):
-                class_label = plot_name.replace("shap_summary_class_", "")
-                section_title = (
-                    f"SHAP Summary for class {class_label} "
-                    f"({getattr(self, 'shap_model_name', 'model')})"
-                )
-            else:
-                section_title = plot_name
+            section_title = self.plot_titles.get(plot_name, plot_name)
             plots_html += f"""
             <div class="plot" id="{plot_name}" style="text-align:center;margin-bottom:24px;">
                 <h2>{section_title}</h2>
@@ -442,6 +418,32 @@ class FeatureImportanceAnalyzer:
         if hasattr(model, "decision_function"):
             return model.decision_function
         return model.predict
+
+    @staticmethod
+    def _safe_label(label):
+        return (
+            str(label)
+            .replace("/", "_")
+            .replace("\\", "_")
+            .replace(" ", "_")
+        )
+
+    def _class_label_for_display(self, label):
+        if self.exp is None:
+            return label
+        try:
+            from pycaret.utils.generic import get_label_encoder
+
+            label_encoder = get_label_encoder(self.exp.pipeline)
+        except Exception:
+            label_encoder = None
+        if label_encoder is None:
+            return label
+        try:
+            decoded = label_encoder.inverse_transform([label])
+            return decoded[0]
+        except Exception:
+            return label
 
     def _choose_shap_explainer(self, model, bg, predict_fn):
         """

--- a/tools/tabularlearner/pycaret_classification.py
+++ b/tools/tabularlearner/pycaret_classification.py
@@ -6,6 +6,12 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 from base_model_trainer import BaseModelTrainer
+from classification_metrics import (
+    labels_in_sample_order,
+    positive_class_label,
+    probability_class_labels,
+    weighted_ovr_pr_auc,
+)
 from dashboard import generate_classifier_explainer_dashboard
 from pycaret.classification import ClassificationExperiment
 from sklearn.decomposition import PCA
@@ -13,7 +19,6 @@ from sklearn.manifold import TSNE
 from sklearn.metrics import (
     auc,
     confusion_matrix,
-    matthews_corrcoef,
     precision_recall_curve,
     precision_recall_fscore_support,
     roc_curve,
@@ -193,18 +198,19 @@ class ClassificationModelTrainer(BaseModelTrainer):
         # a dict to hold the raw Figure objects or callables
         self.explainer_plots: Dict[str, go.Figure] = {}
 
-        y_true, y_pred, label_values, y_scores = self._get_test_predictions()
+        (
+            y_true,
+            y_pred,
+            _,
+            y_scores,
+            score_labels,
+        ) = self._get_test_predictions()
         y_true_display = self._get_original_test_labels_for_display(y_true)
         y_pred_display = self._decode_labels_for_display(y_pred)
-        label_values_display = pd.unique(
-            pd.concat(
-                [
-                    pd.Series(y_true_display),
-                    pd.Series(y_pred_display),
-                ],
-                ignore_index=True,
-            )
-        ).tolist()
+        label_values_display = labels_in_sample_order(
+            y_true_display,
+            y_pred_display,
+        )
 
         # — Classification report (Plotly table) —
         try:
@@ -249,7 +255,11 @@ class ClassificationModelTrainer(BaseModelTrainer):
             try:
                 if y_scores is None:
                     raise ValueError("Predicted probabilities unavailable")
-                fpr, tpr, thr = roc_curve(y_true, y_scores)
+                pos_label = positive_class_label(score_labels)
+                y_true_curve = (
+                    pd.Series(y_true).reset_index(drop=True) == pos_label
+                ).astype(int)
+                fpr, tpr, thr = roc_curve(y_true_curve, y_scores)
                 roc_auc = auc(fpr, tpr)
                 fig_roc = go.Figure()
                 fig_roc.add_scatter(
@@ -280,7 +290,11 @@ class ClassificationModelTrainer(BaseModelTrainer):
 
             # ---- PR with threshold marker ----
             try:
-                fig_pr = self._build_precision_recall_fig(y_true, y_scores)
+                fig_pr = self._build_precision_recall_fig(
+                    y_true,
+                    y_scores,
+                    positive_class_label(score_labels),
+                )
                 if fig_pr is None:
                     raise ValueError("Predicted probabilities unavailable")
                 self.explainer_plots["pr_auc"] = fig_pr
@@ -289,11 +303,37 @@ class ClassificationModelTrainer(BaseModelTrainer):
 
         if "pr_auc" not in self.explainer_plots:
             try:
-                fig_pr = self._build_precision_recall_fig(y_true, y_scores)
+                fig_pr = self._build_precision_recall_fig(
+                    y_true,
+                    y_scores,
+                    positive_class_label(score_labels),
+                )
                 if fig_pr is not None:
                     self.explainer_plots["pr_auc"] = fig_pr
             except Exception as e:
                 LOG.warning(f"Could not generate custom PR curve: {e}")
+
+        if getattr(self.exp, "is_multiclass", False) and y_scores is not None:
+            try:
+                fig_roc = self._build_multiclass_roc_fig(
+                    y_true,
+                    y_scores,
+                    score_labels,
+                )
+                if fig_roc is not None:
+                    self.explainer_plots["roc_auc"] = fig_roc
+            except Exception as e:
+                LOG.warning(f"Could not generate custom multiclass ROC curve: {e}")
+            try:
+                fig_pr = self._build_multiclass_precision_recall_fig(
+                    y_true,
+                    y_scores,
+                    score_labels,
+                )
+                if fig_pr is not None:
+                    self.explainer_plots["pr_auc"] = fig_pr
+            except Exception as e:
+                LOG.warning(f"Could not generate custom multiclass PR curve: {e}")
 
         if explainer is None:
             return
@@ -377,9 +417,15 @@ class ClassificationModelTrainer(BaseModelTrainer):
         prob_thresh = getattr(self, "probability_threshold", None)
 
         y_scores = None
+        score_labels = []
         try:
             proba = self.best_model.predict_proba(X_test)
-            y_scores = proba
+            y_scores = np.asarray(proba)
+            score_labels = probability_class_labels(
+                y_true,
+                y_scores,
+                getattr(self.best_model, "classes_", []),
+            )
         except Exception:
             LOG.debug("predict_proba unavailable for test predictions.")
 
@@ -391,15 +437,21 @@ class ClassificationModelTrainer(BaseModelTrainer):
                 and y_scores.ndim == 2
                 and y_scores.shape[1] > 1
             ):
-                classes = list(getattr(self.best_model, "classes_", []))
+                classes = score_labels or list(
+                    getattr(self.best_model, "classes_", [])
+                )
+                pos_label = positive_class_label(classes)
                 try:
-                    pos_idx = classes.index(1) if 1 in classes else 1
+                    pos_idx = classes.index(pos_label)
                 except Exception:
-                    pos_idx = 1
+                    pos_idx = min(1, y_scores.shape[1] - 1)
                 neg_idx = 1 - pos_idx if y_scores.shape[1] > 1 else 0
-                pos_label = classes[pos_idx] if len(classes) > pos_idx else 1
                 neg_label = classes[neg_idx] if len(classes) > neg_idx else 0
-                y_pred = np.where(y_scores[:, pos_idx] >= prob_thresh, pos_label, neg_label)
+                y_pred = np.where(
+                    y_scores[:, pos_idx] >= prob_thresh,
+                    pos_label,
+                    neg_label,
+                )
                 y_scores = y_scores[:, pos_idx]
             else:
                 y_pred = self.best_model.predict(X_test)
@@ -412,11 +464,18 @@ class ClassificationModelTrainer(BaseModelTrainer):
             y_scores = np.asarray(y_scores)
             if y_scores.ndim > 1 and y_scores.shape[1] == 1:
                 y_scores = y_scores.ravel()
-            if self.exp.is_multiclass and y_scores.ndim > 1:
-                # Avoid passing multiclass score matrices to ROC/PR utilities
-                y_scores = None
-        label_values = pd.unique(pd.concat([y_true, y_pred], ignore_index=True))
-        return y_true, y_pred, label_values.tolist(), y_scores
+            elif not self.exp.is_multiclass and y_scores.ndim > 1:
+                classes = score_labels or list(
+                    getattr(self.best_model, "classes_", [])
+                )
+                pos_label = positive_class_label(classes)
+                try:
+                    pos_idx = classes.index(pos_label)
+                except Exception:
+                    pos_idx = min(1, y_scores.shape[1] - 1)
+                y_scores = y_scores[:, pos_idx]
+        label_values = labels_in_sample_order(y_true, y_pred)
+        return y_true, y_pred, label_values, y_scores, score_labels
 
     def _decode_labels_for_display(self, values):
         """Map transformed class ids back to the original target labels for plots."""
@@ -487,13 +546,7 @@ class ClassificationModelTrainer(BaseModelTrainer):
     def _plot_labeled_scatter(self, fig, x, y, labels, hover_text=None):
         labels = pd.Series(labels).reset_index(drop=True)
 
-        def _label_sort_key(lbl):
-            try:
-                return (0, float(lbl))
-            except Exception:
-                return (1, str(lbl))
-
-        for label in sorted(pd.unique(labels), key=_label_sort_key):
+        for label in labels_in_sample_order(labels):
             mask = labels == label
             if pd.isna(label):
                 mask = labels.isna()
@@ -625,7 +678,7 @@ class ClassificationModelTrainer(BaseModelTrainer):
         except Exception:
             return f" (threshold={prob_thresh})"
 
-    def _build_precision_recall_fig(self, y_true, y_scores):
+    def _build_precision_recall_fig(self, y_true, y_scores, pos_label=None):
         """
         Build a binary precision-recall curve with recall on X and precision on Y.
         Returns None when class probabilities are unavailable or not binary.
@@ -637,7 +690,12 @@ class ClassificationModelTrainer(BaseModelTrainer):
         if y_scores.ndim != 1:
             return None
 
-        precision, recall, thr_pr = precision_recall_curve(y_true, y_scores)
+        y_true_curve = (
+            (pd.Series(y_true).reset_index(drop=True) == pos_label).astype(int)
+            if pos_label is not None
+            else y_true
+        )
+        precision, recall, thr_pr = precision_recall_curve(y_true_curve, y_scores)
         pr_auc = auc(recall, precision)
         fig_pr = go.Figure()
         fig_pr.add_scatter(
@@ -650,10 +708,10 @@ class ClassificationModelTrainer(BaseModelTrainer):
         prob_thresh = getattr(self, "probability_threshold", None)
         if prob_thresh is not None and len(thr_pr):
             idx_pr = int(np.argmin(np.abs(thr_pr - prob_thresh)))
-            idx_pr = max(0, min(idx_pr, len(recall) - 1))
+            point_idx = max(0, min(idx_pr + 1, len(recall) - 1))
             fig_pr.add_scatter(
-                x=[recall[idx_pr]],
-                y=[precision[idx_pr]],
+                x=[recall[point_idx]],
+                y=[precision[point_idx]],
                 mode="markers",
                 name=f"@ {prob_thresh:.2f}",
                 marker=dict(size=10),
@@ -667,14 +725,94 @@ class ClassificationModelTrainer(BaseModelTrainer):
         _apply_report_layout(fig_pr)
         return fig_pr
 
-    def _build_confusion_matrix_fig(self, y_true, y_pred, labels):
-        def _label_sort_key(lbl):
-            try:
-                return (0, float(lbl))
-            except Exception:
-                return (1, str(lbl))
+    def _score_label_display_names(self, score_labels):
+        decoded = self._decode_labels_for_display(pd.Series(score_labels))
+        return ["NaN" if pd.isna(label) else str(label) for label in decoded]
 
-        ordered_labels = sorted(labels, key=_label_sort_key)
+    def _build_multiclass_roc_fig(self, y_true, y_scores, score_labels):
+        y_scores = np.asarray(y_scores)
+        if y_scores.ndim != 2 or y_scores.shape[1] != len(score_labels):
+            return None
+
+        display_labels = self._score_label_display_names(score_labels)
+        y_true_series = pd.Series(y_true).reset_index(drop=True)
+        fig = go.Figure()
+        added = 0
+        for idx, raw_label in enumerate(score_labels):
+            y_true_bin = (y_true_series == raw_label).astype(int)
+            if len(pd.unique(y_true_bin)) < 2:
+                continue
+            fpr, tpr, _ = roc_curve(y_true_bin, y_scores[:, idx])
+            roc_auc = auc(fpr, tpr)
+            fig.add_scatter(
+                x=fpr,
+                y=tpr,
+                mode="lines",
+                name=f"{display_labels[idx]} (AUC={roc_auc:.3f})",
+            )
+            added += 1
+        if not added:
+            return None
+        fig.add_scatter(
+            x=[0, 1],
+            y=[0, 1],
+            mode="lines",
+            line=dict(color="#777777", dash="dash"),
+            name="Chance",
+        )
+        fig.update_layout(
+            title="One-vs-Rest ROC Curves",
+            xaxis_title="False Positive Rate",
+            yaxis_title="True Positive Rate",
+        )
+        _apply_report_layout(fig)
+        return fig
+
+    def _build_multiclass_precision_recall_fig(self, y_true, y_scores, score_labels):
+        y_scores = np.asarray(y_scores)
+        if y_scores.ndim != 2 or y_scores.shape[1] != len(score_labels):
+            return None
+
+        display_labels = self._score_label_display_names(score_labels)
+        y_true_series = pd.Series(y_true).reset_index(drop=True)
+        weighted_auc = weighted_ovr_pr_auc(
+            y_true_series,
+            y_scores,
+            labels=score_labels,
+        )
+        fig = go.Figure()
+        added = 0
+        for idx, raw_label in enumerate(score_labels):
+            y_true_bin = (y_true_series == raw_label).astype(int)
+            if len(pd.unique(y_true_bin)) < 2:
+                continue
+            precision, recall, _ = precision_recall_curve(
+                y_true_bin,
+                y_scores[:, idx],
+            )
+            pr_auc = auc(recall, precision)
+            fig.add_scatter(
+                x=recall,
+                y=precision,
+                mode="lines",
+                name=f"{display_labels[idx]} (AUC={pr_auc:.3f})",
+            )
+            added += 1
+        if not added:
+            return None
+        title = "One-vs-Rest Precision-Recall Curves"
+        if not np.isnan(weighted_auc):
+            title += f" (weighted AUC={weighted_auc:.3f})"
+        fig.update_layout(
+            title=title,
+            xaxis_title="Recall",
+            yaxis_title="Precision",
+        )
+        _apply_report_layout(fig)
+        return fig
+
+    def _build_confusion_matrix_fig(self, y_true, y_pred, labels):
+        ordered_labels = list(labels)
         cm = confusion_matrix(y_true, y_pred, labels=ordered_labels)
         label_names = [str(lbl) for lbl in ordered_labels]
         fig_cm = go.Figure(
@@ -711,16 +849,6 @@ class ClassificationModelTrainer(BaseModelTrainer):
         precision, recall, f1, support = precision_recall_fscore_support(
             y_true, y_pred, labels=labels, zero_division=0
         )
-        mcc_scores = []
-        for lbl in labels:
-            y_true_bin = (y_true == lbl).astype(int)
-            y_pred_bin = (y_pred == lbl).astype(int)
-            try:
-                mcc_val = matthews_corrcoef(y_true_bin, y_pred_bin)
-            except Exception:
-                mcc_val = 0.0
-            mcc_scores.append(mcc_val)
-
         label_names = [str(lbl) for lbl in labels]
         metrics = ["precision", "recall", "f1", "support"]
 

--- a/tools/tabularlearner/pycaret_classification.py
+++ b/tools/tabularlearner/pycaret_classification.py
@@ -22,6 +22,8 @@ from utils import predict_proba
 
 LOG = logging.getLogger(__name__)
 
+MULTICLASS_UNAVAILABLE_PYCARET_PLOTS = {"threshold"}
+
 
 def _apply_report_layout(fig: go.Figure) -> go.Figure:
     # Give the left side more space for y-axis title/ticks and let axes auto-reserve room
@@ -38,6 +40,13 @@ def _apply_report_layout(fig: go.Figure) -> go.Figure:
         margin=dict(l=120, r=40, t=60, b=60),  # bump 'l' if you still see clipping
     )
     return fig
+
+
+def _should_skip_pycaret_plot(plot_name, exp):
+    return (
+        getattr(exp, "is_multiclass", False)
+        and plot_name in MULTICLASS_UNAVAILABLE_PYCARET_PLOTS
+    )
 
 
 class ClassificationModelTrainer(BaseModelTrainer):
@@ -92,6 +101,12 @@ class ClassificationModelTrainer(BaseModelTrainer):
         ]
         for plot_name in plots:
             try:
+                if _should_skip_pycaret_plot(plot_name, self.exp):
+                    LOG.info(
+                        "Skipping PyCaret %s plot for multiclass classification.",
+                        plot_name,
+                    )
+                    continue
                 if plot_name == "threshold":
                     plot_path = self.exp.plot_model(
                         self.best_model,

--- a/tools/tabularlearner/pycaret_classification.py
+++ b/tools/tabularlearner/pycaret_classification.py
@@ -27,7 +27,11 @@ from utils import predict_proba
 
 LOG = logging.getLogger(__name__)
 
-MULTICLASS_UNAVAILABLE_PYCARET_PLOTS = {"threshold"}
+MULTICLASS_UNAVAILABLE_PYCARET_PLOTS = {
+    "calibration",
+    "rfe",
+    "threshold",
+}
 
 
 def _apply_report_layout(fig: go.Figure) -> go.Figure:
@@ -142,7 +146,11 @@ class ClassificationModelTrainer(BaseModelTrainer):
                     )
                     self.plots[plot_name] = plot_path
             except Exception as e:
-                LOG.error(f"Error generating plot {plot_name}: {e}")
+                LOG.warning(
+                    "Could not generate optional PyCaret plot %s: %s",
+                    plot_name,
+                    e,
+                )
                 continue
 
     def generate_plots_explainer(self):
@@ -353,7 +361,11 @@ class ClassificationModelTrainer(BaseModelTrainer):
                 if fig is not None:
                     self.explainer_plots[key] = fig
             except Exception as e:
-                LOG.error(f"Error generating explainer plot {key}: {e}")
+                LOG.warning(
+                    "Could not generate optional explainer plot %s: %s",
+                    key,
+                    e,
+                )
 
         if self._explainer_feature_count_exceeds_cap():
             LOG.info(
@@ -399,7 +411,7 @@ class ClassificationModelTrainer(BaseModelTrainer):
                         LOG.warning(f"PDP AssertionError for {f!r}: {ae}")
                         return None
                     except Exception as e:
-                        LOG.error(f"Unexpected error plotting PDP for {f!r}: {e}")
+                        LOG.warning(f"Unexpected error plotting PDP for {f!r}: {e}")
                         return None
 
                 return _plot
@@ -477,29 +489,32 @@ class ClassificationModelTrainer(BaseModelTrainer):
         label_values = labels_in_sample_order(y_true, y_pred)
         return y_true, y_pred, label_values, y_scores, score_labels
 
-    def _decode_labels_for_display(self, values):
+    def _decode_labels_for_display(self, values, assume_encoded=True):
         """Map transformed class ids back to the original target labels for plots."""
+        if not assume_encoded:
+            return values
         return self._decode_class_labels_for_display(values)
 
     def _get_original_test_labels_for_display(self, fallback):
         """Return original test labels for report plots when PyCaret exposes them."""
         candidates = []
         if self.test_data is not None and self.target in self.test_data.columns:
-            candidates.append(self.test_data[self.target])
+            candidates.append((self.test_data[self.target], False))
         for key in ("y_test", "y_test_transformed"):
             try:
-                candidates.append(self.exp.get_config(key))
+                value = self.exp.get_config(key)
             except Exception:
-                candidates.append(getattr(self.exp, key, None))
+                value = getattr(self.exp, key, None)
+            candidates.append((value, key.endswith("_transformed")))
 
         fallback_len = len(fallback) if fallback is not None else None
-        for candidate in candidates:
+        for candidate, assume_encoded in candidates:
             if candidate is None:
                 continue
             series = pd.Series(candidate).reset_index(drop=True)
             if fallback_len is not None and len(series) != fallback_len:
                 continue
-            return self._decode_labels_for_display(series)
+            return self._decode_labels_for_display(series, assume_encoded=assume_encoded)
 
         return self._decode_labels_for_display(fallback)
 
@@ -812,9 +827,10 @@ class ClassificationModelTrainer(BaseModelTrainer):
         return fig
 
     def _build_confusion_matrix_fig(self, y_true, y_pred, labels):
-        ordered_labels = list(labels)
-        cm = confusion_matrix(y_true, y_pred, labels=ordered_labels)
-        label_names = [str(lbl) for lbl in ordered_labels]
+        label_names = [str(lbl) for lbl in labels]
+        y_true_display = pd.Series(y_true).map(str)
+        y_pred_display = pd.Series(y_pred).map(str)
+        cm = confusion_matrix(y_true_display, y_pred_display, labels=label_names)
         fig_cm = go.Figure(
             data=go.Heatmap(
                 z=cm,
@@ -846,10 +862,15 @@ class ClassificationModelTrainer(BaseModelTrainer):
         return fig_cm
 
     def _build_classification_report_fig(self, y_true, y_pred, labels):
-        precision, recall, f1, support = precision_recall_fscore_support(
-            y_true, y_pred, labels=labels, zero_division=0
-        )
         label_names = [str(lbl) for lbl in labels]
+        y_true_display = pd.Series(y_true).map(str)
+        y_pred_display = pd.Series(y_pred).map(str)
+        precision, recall, f1, support = precision_recall_fscore_support(
+            y_true_display,
+            y_pred_display,
+            labels=label_names,
+            zero_division=0,
+        )
         metrics = ["precision", "recall", "f1", "support"]
 
         max_support = float(max(support) if len(support) else 0)

--- a/tools/tabularlearner/pycaret_classification.py
+++ b/tools/tabularlearner/pycaret_classification.py
@@ -79,7 +79,10 @@ class ClassificationModelTrainer(BaseModelTrainer):
     def generate_plots(self):
         LOG.info("Generating and saving plots")
 
-        if not hasattr(self.best_model, "predict_proba"):
+        if (
+            not hasattr(self.best_model, "predict_proba")
+            and not getattr(self.exp, "is_multiclass", False)
+        ):
             self.best_model.predict_proba = types.MethodType(
                 predict_proba, self.best_model
             )
@@ -143,7 +146,10 @@ class ClassificationModelTrainer(BaseModelTrainer):
         LOG.info("Generating explainer plots")
 
         # Ensure predict_proba is available here too
-        if not hasattr(self.best_model, "predict_proba"):
+        if (
+            not hasattr(self.best_model, "predict_proba")
+            and not getattr(self.exp, "is_multiclass", False)
+        ):
             self.best_model.predict_proba = types.MethodType(
                 predict_proba, self.best_model
             )
@@ -169,12 +175,20 @@ class ClassificationModelTrainer(BaseModelTrainer):
         explainer_labels = (
             list(label_encoder.classes_) if label_encoder is not None else None
         )
-        explainer = ClassifierExplainer(
-            self.best_model,
-            X_test,
-            y_test,
-            labels=explainer_labels,
-        )
+        explainer = None
+        try:
+            explainer = ClassifierExplainer(
+                self.best_model,
+                X_test,
+                y_test,
+                labels=explainer_labels,
+            )
+        except Exception as exc:
+            LOG.warning(
+                "Could not initialize ClassifierExplainer; "
+                "continuing with custom classification plots only: %s",
+                exc,
+            )
 
         # a dict to hold the raw Figure objects or callables
         self.explainer_plots: Dict[str, go.Figure] = {}
@@ -280,6 +294,9 @@ class ClassificationModelTrainer(BaseModelTrainer):
                     self.explainer_plots["pr_auc"] = fig_pr
             except Exception as e:
                 LOG.warning(f"Could not generate custom PR curve: {e}")
+
+        if explainer is None:
+            return
 
         # these go into the Test tab (don't overwrite overrides)
         for key, fn in [

--- a/tools/tabularlearner/pycaret_predict.py
+++ b/tools/tabularlearner/pycaret_predict.py
@@ -81,6 +81,20 @@ def pr_auc_curve_score(y_true, y_score):
     return _weighted_ovr_pr_auc(y_true, y_score)
 
 
+def _add_pr_auc_metric_if_supported(exp):
+    if getattr(exp, "is_multiclass", False):
+        LOG.info(
+            "Skipping PyCaret custom PR-AUC metric for multiclass "
+            "classification."
+        )
+        return False
+    exp.add_metric(id='PR-AUC',
+                   name='PR-AUC',
+                   target='pred_proba',
+                   score_func=pr_auc_curve_score)
+    return True
+
+
 class PyCaretModelEvaluator:
     def __init__(self, model_path, task, target):
         self.model_path = model_path
@@ -115,10 +129,7 @@ class ClassificationEvaluator(PyCaretModelEvaluator):
             target_index = int(self.target) - 1
             target_name = names[target_index]
             exp.setup(data, target=target_name, test_data=data, index=False)
-            exp.add_metric(id='PR-AUC',
-                           name='PR-AUC',
-                           target='pred_proba',
-                           score_func=pr_auc_curve_score)
+            _add_pr_auc_metric_if_supported(exp)
             predictions = exp.predict_model(self.model)
             metrics = exp.pull()
             plots = ['confusion_matrix', 'auc', 'threshold', 'pr',

--- a/tools/tabularlearner/pycaret_predict.py
+++ b/tools/tabularlearner/pycaret_predict.py
@@ -19,7 +19,11 @@ from utils import (
 LOG = logging.getLogger(__name__)
 
 
-MULTICLASS_UNAVAILABLE_PYCARET_PLOTS = {"threshold"}
+MULTICLASS_UNAVAILABLE_PYCARET_PLOTS = {
+    "calibration",
+    "rfe",
+    "threshold",
+}
 
 
 def _should_skip_pycaret_plot(plot_name, exp):
@@ -113,7 +117,11 @@ class ClassificationEvaluator(PyCaretModelEvaluator):
                                                plot=plot_name, save=True)
                     plot_paths[plot_name] = plot_path
                 except Exception as e:
-                    LOG.error(f"Error generating plot {plot_name}: {e}")
+                    LOG.warning(
+                        "Could not generate optional PyCaret plot %s: %s",
+                        plot_name,
+                        e,
+                    )
                     continue
             generate_html_report(plot_paths, metrics)
 
@@ -147,7 +155,11 @@ class RegressionEvaluator(PyCaretModelEvaluator):
                                                plot=plot_name, save=True)
                     plot_paths[plot_name] = plot_path
                 except Exception as e:
-                    LOG.error(f"Error generating plot {plot_name}: {e}")
+                    LOG.warning(
+                        "Could not generate optional PyCaret plot %s: %s",
+                        plot_name,
+                        e,
+                    )
                     continue
             generate_html_report(plot_paths, metrics)
         else:

--- a/tools/tabularlearner/pycaret_predict.py
+++ b/tools/tabularlearner/pycaret_predict.py
@@ -4,11 +4,10 @@ import tempfile
 
 import h5py
 import joblib
-import numpy as np
 import pandas as pd
+from classification_metrics import weighted_ovr_pr_auc as _weighted_ovr_pr_auc
 from pycaret.classification import ClassificationExperiment
 from pycaret.regression import RegressionExperiment
-from sklearn.metrics import auc, precision_recall_curve
 from utils import (
     build_tabbed_html,
     encode_image_to_base64,
@@ -28,63 +27,6 @@ def _should_skip_pycaret_plot(plot_name, exp):
         getattr(exp, "is_multiclass", False)
         and plot_name in MULTICLASS_UNAVAILABLE_PYCARET_PLOTS
     )
-
-
-def _weighted_ovr_pr_auc(y_true, y_score, labels=None):
-    y_true_series = pd.Series(y_true).reset_index(drop=True)
-    if labels is not None:
-        class_labels = list(labels)
-    else:
-        class_labels = list(pd.unique(y_true_series))
-        try:
-            class_labels = sorted(class_labels)
-        except Exception:
-            pass
-    if len(class_labels) < 2:
-        return np.nan
-
-    scores = np.asarray(y_score)
-    if len(scores) != len(y_true_series):
-        return np.nan
-
-    if len(class_labels) == 2:
-        try:
-            pos_label = 1 if 1 in class_labels else sorted(class_labels)[-1]
-        except Exception:
-            pos_label = class_labels[-1]
-        if scores.ndim == 2:
-            if scores.shape[1] < 2:
-                scores = scores.ravel()
-            else:
-                try:
-                    pos_idx = class_labels.index(pos_label)
-                except ValueError:
-                    pos_idx = scores.shape[1] - 1
-                scores = scores[:, min(pos_idx, scores.shape[1] - 1)]
-        precision, recall, _ = precision_recall_curve(
-            (y_true_series == pos_label).astype(int),
-            scores,
-        )
-        return auc(recall, precision)
-
-    if scores.ndim != 2 or scores.shape[1] < len(class_labels):
-        return np.nan
-
-    weighted_total = 0.0
-    support_total = 0
-    for class_idx, class_label in enumerate(class_labels):
-        y_true_bin = (y_true_series == class_label).astype(int)
-        if len(pd.unique(y_true_bin)) < 2:
-            continue
-        precision, recall, _ = precision_recall_curve(
-            y_true_bin,
-            scores[:, class_idx],
-        )
-        support = int(y_true_bin.sum())
-        weighted_total += auc(recall, precision) * support
-        support_total += support
-
-    return weighted_total / support_total if support_total else np.nan
 
 
 def pr_auc_curve_score(y_true, y_score):

--- a/tools/tabularlearner/pycaret_predict.py
+++ b/tools/tabularlearner/pycaret_predict.py
@@ -20,6 +20,16 @@ from utils import (
 LOG = logging.getLogger(__name__)
 
 
+MULTICLASS_UNAVAILABLE_PYCARET_PLOTS = {"threshold"}
+
+
+def _should_skip_pycaret_plot(plot_name, exp):
+    return (
+        getattr(exp, "is_multiclass", False)
+        and plot_name in MULTICLASS_UNAVAILABLE_PYCARET_PLOTS
+    )
+
+
 def _weighted_ovr_pr_auc(y_true, y_score, labels=None):
     y_true_series = pd.Series(y_true).reset_index(drop=True)
     if labels is not None:
@@ -138,6 +148,13 @@ class ClassificationEvaluator(PyCaretModelEvaluator):
                      'feature_all']
             for plot_name in plots:
                 try:
+                    if _should_skip_pycaret_plot(plot_name, exp):
+                        LOG.info(
+                            "Skipping PyCaret %s plot for multiclass "
+                            "classification.",
+                            plot_name,
+                        )
+                        continue
                     if plot_name == 'auc' and not exp.is_multiclass:
                         plot_path = exp.plot_model(self.model,
                                                    plot=plot_name,

--- a/tools/tabularlearner/pycaret_predict.xml
+++ b/tools/tabularlearner/pycaret_predict.xml
@@ -4,6 +4,11 @@
         <import>pycaret_macros.xml</import>
     </macros>
     <expand macro="python_requirements" />
+    <required_files>
+        <include path="classification_metrics.py" />
+        <include path="pycaret_predict.py" />
+        <include path="utils.py" />
+    </required_files>
     <command>
         <![CDATA[
         echo $target_feature && 

--- a/tools/tabularlearner/pycaret_regression.py
+++ b/tools/tabularlearner/pycaret_regression.py
@@ -98,8 +98,8 @@ class RegressionModelTrainer(BaseModelTrainer):
 
             # --- 2) SHAP permutation importance ---
             try:
-                self.explainer_plots["shap_perm"] = explainer.plot_importances_permutation(
-                    kind="permutation"
+                self.explainer_plots["shap_perm"] = lambda: explainer.plot_importances(
+                    kind="permutation",
                 )
             except Exception as e:
                 LOG.error(f"Error generating SHAP permutation importance: {e}")

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -4,6 +4,18 @@
         <import>pycaret_macros.xml</import>
     </macros>
     <expand macro="python_requirements" />
+    <required_files>
+        <include path="base_model_trainer.py" />
+        <include path="classification_metrics.py" />
+        <include path="dashboard.py" />
+        <include path="explainability_limits.py" />
+        <include path="feature_help_modal.py" />
+        <include path="feature_importance.py" />
+        <include path="pycaret_classification.py" />
+        <include path="pycaret_regression.py" />
+        <include path="pycaret_train.py" />
+        <include path="utils.py" />
+    </required_files>
     <command>
         <![CDATA[
         python $__tool_directory__/pycaret_train.py --input_file '$data_configuration.input_file' --target_col '$data_configuration.target_feature' --output_dir '.' --random_seed '$customize_defaults_section.random_seed' --n-jobs \${GALAXY_SLOTS:-1}

--- a/tools/tabularlearner/test_multiclass_pr_auc_metric.py
+++ b/tools/tabularlearner/test_multiclass_pr_auc_metric.py
@@ -1,0 +1,115 @@
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+
+
+TOOL_DIR = Path(__file__).resolve().parent
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+
+def _install_import_stubs():
+    sys.modules.setdefault("shap", types.ModuleType("shap"))
+
+    pycaret = sys.modules.setdefault("pycaret", types.ModuleType("pycaret"))
+    classification = sys.modules.setdefault(
+        "pycaret.classification", types.ModuleType("pycaret.classification")
+    )
+    regression = sys.modules.setdefault(
+        "pycaret.regression", types.ModuleType("pycaret.regression")
+    )
+
+    class ClassificationExperiment:
+        pass
+
+    class RegressionExperiment:
+        pass
+
+    classification.ClassificationExperiment = ClassificationExperiment
+    regression.RegressionExperiment = RegressionExperiment
+    pycaret.classification = classification
+    pycaret.regression = regression
+
+
+_install_import_stubs()
+
+from base_model_trainer import BaseModelTrainer, _add_pr_auc_metric_if_supported
+from pycaret_predict import _add_pr_auc_metric_if_supported as add_predict_pr_auc
+
+
+class FakeModel:
+    def predict(self, X=None):
+        return []
+
+
+class FakeExperiment:
+    def __init__(self, is_multiclass):
+        self.is_multiclass = is_multiclass
+        self.metric_added = False
+        self.compare_kwargs = None
+        self.predict_called = False
+
+    def add_metric(self, **kwargs):
+        self.metric_added = True
+        self.metric_kwargs = kwargs
+
+    def compare_models(self, **kwargs):
+        self.compare_kwargs = kwargs
+        return FakeModel()
+
+    def pull(self):
+        return pd.DataFrame({"AUC": [0.75]})
+
+    def predict_model(self, model, **kwargs):
+        if self.metric_added and self.is_multiclass:
+            raise ValueError("Shape of passed values is (60, 5), indices imply (60, 1)")
+        self.predict_called = True
+        return pd.DataFrame()
+
+
+def test_training_pr_auc_metric_is_skipped_for_multiclass():
+    exp = FakeExperiment(is_multiclass=True)
+
+    added = _add_pr_auc_metric_if_supported(exp)
+
+    assert added is False
+    assert exp.metric_added is False
+
+
+def test_training_pr_auc_metric_is_added_for_binary():
+    exp = FakeExperiment(is_multiclass=False)
+
+    added = _add_pr_auc_metric_if_supported(exp)
+
+    assert added is True
+    assert exp.metric_added is True
+    assert exp.metric_kwargs["target"] == "pred_proba"
+
+
+def test_multiclass_train_model_does_not_register_pr_auc_before_predict_model(tmp_path):
+    trainer = BaseModelTrainer(
+        input_file="unused.tsv",
+        target_col="1",
+        output_dir=str(tmp_path),
+        task_type="classification",
+        random_seed=42,
+        best_model_metric="PR-AUC",
+    )
+    trainer.exp = FakeExperiment(is_multiclass=True)
+
+    trainer.train_model()
+
+    assert trainer.exp.metric_added is False
+    assert trainer.exp.compare_kwargs["sort"] == "AUC"
+    assert trainer.exp.predict_called is True
+
+
+def test_predict_evaluator_pr_auc_metric_is_skipped_for_multiclass():
+    exp = FakeExperiment(is_multiclass=True)
+
+    added = add_predict_pr_auc(exp)
+
+    assert added is False
+    assert exp.metric_added is False

--- a/tools/tabularlearner/test_multiclass_pr_auc_metric.py
+++ b/tools/tabularlearner/test_multiclass_pr_auc_metric.py
@@ -47,10 +47,17 @@ def _install_import_stubs():
 _install_import_stubs()
 
 from base_model_trainer import BaseModelTrainer, _add_pr_auc_metric_if_supported
+from classification_metrics import (
+    labels_in_metric_order,
+    labels_in_sample_order,
+    weighted_ovr_pr_auc,
+)
+from feature_importance import FeatureImportanceAnalyzer
 from pycaret_classification import (
     ClassificationModelTrainer,
     _should_skip_pycaret_plot,
 )
+from pycaret_regression import RegressionModelTrainer
 from pycaret_predict import _add_pr_auc_metric_if_supported as add_predict_pr_auc
 
 
@@ -253,3 +260,322 @@ def test_multiclass_explainer_failure_keeps_custom_plots(monkeypatch):
 
     assert "class_report" in trainer.explainer_plots
     assert "confusion_matrix" in trainer.explainer_plots
+
+
+def test_weighted_multiclass_pr_auc_uses_probability_column_label_order():
+    y_true = pd.Series(["beta", "alpha", "gamma", "beta", "alpha", "gamma"])
+    class_order = ["gamma", "alpha", "beta"]
+    y_score = np.array(
+        [
+            [0.05, 0.10, 0.85],
+            [0.10, 0.80, 0.10],
+            [0.90, 0.05, 0.05],
+            [0.05, 0.20, 0.75],
+            [0.15, 0.70, 0.15],
+            [0.80, 0.10, 0.10],
+        ]
+    )
+
+    assert weighted_ovr_pr_auc(y_true, y_score, labels=class_order) == 1.0
+    assert weighted_ovr_pr_auc(
+        y_true,
+        y_score,
+        labels=labels_in_sample_order(y_true),
+    ) < 1.0
+
+
+def test_binary_pr_auc_default_label_order_is_metric_stable():
+    y_true = pd.Series(["yes", "no", "yes", "no"])
+    y_score = np.array([0.9, 0.2, 0.8, 0.1])
+
+    assert labels_in_sample_order(y_true) == ["yes", "no"]
+    assert labels_in_metric_order(y_true) == ["no", "yes"]
+    assert weighted_ovr_pr_auc(y_true, y_score) == 1.0
+
+
+def test_report_confusion_matrix_preserves_sample_label_order():
+    trainer = object.__new__(ClassificationModelTrainer)
+    trainer.task_type = "classification"
+    trainer.target = "target"
+    trainer.exp = FakeExperiment(is_multiclass=True)
+
+    labels = ["beta", "alpha", "gamma"]
+    fig = trainer._build_confusion_matrix_fig(
+        pd.Series(["beta", "alpha", "gamma"]),
+        pd.Series(["beta", "gamma", "gamma"]),
+        labels,
+    )
+
+    assert fig.data[0].x == tuple(f"Pred {label}" for label in labels)
+    assert fig.data[0].y == tuple(f"True {label}" for label in labels)
+
+
+def test_labeled_scatter_preserves_sample_label_order():
+    import plotly.graph_objects as go
+
+    trainer = object.__new__(ClassificationModelTrainer)
+    fig = go.Figure()
+
+    trainer._plot_labeled_scatter(
+        fig,
+        x=np.array([0, 1, 2]),
+        y=np.array([0, 1, 2]),
+        labels=pd.Series(["beta", "alpha", "gamma"]),
+    )
+
+    assert [trace.name for trace in fig.data] == ["beta", "alpha", "gamma"]
+
+
+def test_multiclass_custom_curves_use_model_class_order_and_display_labels():
+    trainer = object.__new__(ClassificationModelTrainer)
+    trainer.task_type = "classification"
+    trainer.target = "target"
+    trainer.exp = FakeExperiment(is_multiclass=True)
+    trainer._decode_labels_for_display = lambda values: values
+
+    y_true = pd.Series(["beta", "alpha", "gamma", "beta", "alpha", "gamma"])
+    score_labels = ["gamma", "alpha", "beta"]
+    y_score = np.array(
+        [
+            [0.05, 0.10, 0.85],
+            [0.10, 0.80, 0.10],
+            [0.90, 0.05, 0.05],
+            [0.05, 0.20, 0.75],
+            [0.15, 0.70, 0.15],
+            [0.80, 0.10, 0.10],
+        ]
+    )
+
+    roc_fig = trainer._build_multiclass_roc_fig(y_true, y_score, score_labels)
+    pr_fig = trainer._build_multiclass_precision_recall_fig(
+        y_true,
+        y_score,
+        score_labels,
+    )
+
+    assert [trace.name for trace in roc_fig.data[:3]] == [
+        "gamma (AUC=1.000)",
+        "alpha (AUC=1.000)",
+        "beta (AUC=1.000)",
+    ]
+    assert [trace.name for trace in pr_fig.data] == [
+        "gamma (AUC=1.000)",
+        "alpha (AUC=1.000)",
+        "beta (AUC=1.000)",
+    ]
+
+
+def test_regression_permutation_importance_uses_supported_explainer_api(monkeypatch):
+    calls = []
+    explainerdashboard = types.ModuleType("explainerdashboard")
+
+    class FakeRegressionExplainer:
+        X = pd.DataFrame({"feature": [0, 1]})
+        onehot_cols = []
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def plot_importances(self, **kwargs):
+            calls.append(kwargs)
+            return "importance"
+
+        def plot_pdp(self, feature):
+            return f"pdp-{feature}"
+
+        def plot_predicted_vs_actual(self):
+            return "predicted-vs-actual"
+
+        def plot_residuals(self):
+            return "residuals"
+
+        def plot_residuals_vs_feature(self, feature):
+            return f"residuals-{feature}"
+
+    explainerdashboard.RegressionExplainer = FakeRegressionExplainer
+    monkeypatch.setitem(sys.modules, "explainerdashboard", explainerdashboard)
+
+    trainer = object.__new__(RegressionModelTrainer)
+    trainer.best_model = object()
+    trainer.exp = types.SimpleNamespace(
+        X_test_transformed=pd.DataFrame({"feature": [0, 1]}),
+        y_test_transformed=pd.Series([0.0, 1.0]),
+    )
+    trainer.random_seed = 42
+    trainer.plot_feature_names = []
+    trainer.explainer_plots = {}
+    trainer.explainer_scope = types.SimpleNamespace(
+        total_features=1,
+        feature_cap=30,
+    )
+    trainer.explainer_dashboard_importance_skipped = False
+    trainer._limit_explainer_data = lambda X, y, **kwargs: (X, y)
+    trainer._explainer_feature_count_exceeds_cap = lambda: False
+
+    trainer.generate_plots_explainer()
+    trainer.explainer_plots["shap_perm"]()
+
+    assert {"kind": "permutation"} in calls
+
+
+class FakeShapExplanation:
+    def __init__(self, shape, selected=None):
+        self.shape = shape
+        self.selected = [] if selected is None else selected
+
+    def __getitem__(self, key):
+        if isinstance(key, tuple) and len(key) == 2:
+            class_idx = key[1]
+            return FakeShapExplanation(self.shape[:2], self.selected + [class_idx])
+        raise AssertionError(f"Unexpected SHAP slice: {key!r}")
+
+
+class FakeShapExplainer:
+    def __init__(self, explanation):
+        self.explanation = explanation
+
+    def __call__(self, X):
+        return self.explanation
+
+
+def _build_shap_analyzer(tmp_path, task_type, model, explanation, max_features=1):
+    analyzer = object.__new__(FeatureImportanceAnalyzer)
+    analyzer.task_type = task_type
+    analyzer.best_model = model
+    analyzer.exp = types.SimpleNamespace(pipeline=None)
+    analyzer.output_dir = str(tmp_path)
+    analyzer.plots = {}
+    analyzer.plot_titles = {}
+    analyzer.max_shap_rows = None
+    analyzer.max_plot_features = max_features
+    analyzer.polynomial_features = False
+    analyzer._get_transformed_frame = lambda model, prefer_test=True: pd.DataFrame(
+        {
+            "f1": [0.0, 1.0],
+            "f2": [2.0, 3.0],
+            "f3": [4.0, 5.0],
+        }
+    )
+    analyzer._choose_shap_explainer = lambda model, bg, predict_fn: (
+        FakeShapExplainer(explanation),
+        "fake",
+        False,
+    )
+    return analyzer
+
+
+def test_custom_shap_binary_plots_positive_class_only_with_display_cap(
+    monkeypatch,
+    tmp_path,
+):
+    import feature_importance
+
+    beeswarm_calls = []
+    monkeypatch.setattr(
+        feature_importance.shap,
+        "plots",
+        types.SimpleNamespace(
+            beeswarm=lambda explanation, **kwargs: beeswarm_calls.append(
+                (explanation.shape, explanation.selected, kwargs)
+            )
+        ),
+        raising=False,
+    )
+
+    class FakeBinaryModel:
+        classes_ = ["control", "case"]
+
+        def predict_proba(self, X):
+            return np.ones((len(X), 2)) * 0.5
+
+    explanation = FakeShapExplanation((2, 3, 2))
+    analyzer = _build_shap_analyzer(
+        tmp_path,
+        "classification",
+        FakeBinaryModel(),
+        explanation,
+        max_features=1,
+    )
+
+    analyzer.save_shap_values()
+
+    assert beeswarm_calls == [((2, 3), [1], {"max_display": 1, "show": False})]
+    assert list(analyzer.plots) == ["shap_summary_class_case"]
+    assert "class case" in analyzer.plot_titles["shap_summary_class_case"]
+    assert analyzer.shap_used_features == 3
+
+
+def test_custom_shap_multiclass_plots_each_model_class(monkeypatch, tmp_path):
+    import feature_importance
+
+    beeswarm_calls = []
+    monkeypatch.setattr(
+        feature_importance.shap,
+        "plots",
+        types.SimpleNamespace(
+            beeswarm=lambda explanation, **kwargs: beeswarm_calls.append(
+                (explanation.shape, explanation.selected, kwargs)
+            )
+        ),
+        raising=False,
+    )
+
+    class FakeMulticlassModel:
+        classes_ = ["gamma", "alpha", "beta"]
+
+        def predict_proba(self, X):
+            return np.ones((len(X), 3)) / 3
+
+    explanation = FakeShapExplanation((2, 3, 3))
+    analyzer = _build_shap_analyzer(
+        tmp_path,
+        "classification",
+        FakeMulticlassModel(),
+        explanation,
+        max_features=2,
+    )
+
+    analyzer.save_shap_values()
+
+    assert [call[1] for call in beeswarm_calls] == [[0], [1], [2]]
+    assert list(analyzer.plots) == [
+        "shap_summary_class_gamma",
+        "shap_summary_class_alpha",
+        "shap_summary_class_beta",
+    ]
+    assert all(call[2]["max_display"] == 2 for call in beeswarm_calls)
+
+
+def test_custom_shap_regression_plots_single_summary(monkeypatch, tmp_path):
+    import feature_importance
+
+    beeswarm_calls = []
+    monkeypatch.setattr(
+        feature_importance.shap,
+        "plots",
+        types.SimpleNamespace(
+            beeswarm=lambda explanation, **kwargs: beeswarm_calls.append(
+                (explanation.shape, explanation.selected, kwargs)
+            )
+        ),
+        raising=False,
+    )
+
+    class FakeRegressionModel:
+        def predict(self, X):
+            return np.zeros(len(X))
+
+    explanation = FakeShapExplanation((2, 3))
+    analyzer = _build_shap_analyzer(
+        tmp_path,
+        "regression",
+        FakeRegressionModel(),
+        explanation,
+        max_features=2,
+    )
+
+    analyzer.save_shap_values()
+
+    assert beeswarm_calls == [((2, 3), [], {"max_display": 2, "show": False})]
+    assert list(analyzer.plots) == ["shap_summary"]
+    assert analyzer.shap_used_features == 3

--- a/tools/tabularlearner/test_multiclass_pr_auc_metric.py
+++ b/tools/tabularlearner/test_multiclass_pr_auc_metric.py
@@ -161,8 +161,8 @@ class FakePlotExperiment:
 
     def plot_model(self, model, plot, save=True, plot_kwargs=None):
         self.plot_calls.append(plot)
-        if plot == "threshold":
-            raise AssertionError("threshold plot should be skipped for multiclass")
+        if plot in {"calibration", "rfe", "threshold"}:
+            raise AssertionError(f"{plot} plot should be skipped for multiclass")
         return f"{plot}.png"
 
 
@@ -235,7 +235,7 @@ def test_predict_evaluator_pr_auc_metric_is_skipped_for_multiclass():
     assert exp.metric_added is False
 
 
-def test_multiclass_threshold_plot_is_skipped():
+def test_multiclass_unsupported_pycaret_plots_are_skipped():
     exp = FakePlotExperiment()
     trainer = object.__new__(ClassificationModelTrainer)
     trainer.best_model = FakeModel()
@@ -245,8 +245,14 @@ def test_multiclass_threshold_plot_is_skipped():
     trainer.generate_plots()
 
     assert _should_skip_pycaret_plot("threshold", exp) is True
+    assert _should_skip_pycaret_plot("calibration", exp) is True
+    assert _should_skip_pycaret_plot("rfe", exp) is True
     assert "threshold" not in exp.plot_calls
+    assert "calibration" not in exp.plot_calls
+    assert "rfe" not in exp.plot_calls
     assert "threshold" not in trainer.plots
+    assert "calibration" not in trainer.plots
+    assert "rfe" not in trainer.plots
     assert "auc" in exp.plot_calls
 
 
@@ -337,6 +343,42 @@ def test_report_confusion_matrix_preserves_sample_label_order():
 
     assert fig.data[0].x == tuple(f"Pred {label}" for label in labels)
     assert fig.data[0].y == tuple(f"True {label}" for label in labels)
+
+
+def test_original_test_labels_are_not_decoded_again(monkeypatch):
+    generic = sys.modules["pycaret.utils.generic"]
+
+    class LabelEncoder:
+        classes_ = np.array([1, 2, 3, 4, 5])
+
+        def inverse_transform(self, values):
+            return np.asarray(values) + 1
+
+    monkeypatch.setattr(
+        generic,
+        "get_label_encoder",
+        lambda pipeline: LabelEncoder(),
+    )
+
+    class ExperimentWithOriginalLabels:
+        pipeline = None
+
+        def get_config(self, key):
+            if key == "y_test":
+                return pd.Series([1, 5])
+            if key == "y_test_transformed":
+                return pd.Series([0, 4])
+            raise KeyError(key)
+
+    trainer = object.__new__(ClassificationModelTrainer)
+    trainer.task_type = "classification"
+    trainer.target = "AGE"
+    trainer.test_data = None
+    trainer.exp = ExperimentWithOriginalLabels()
+
+    labels = trainer._get_original_test_labels_for_display(pd.Series([0, 4]))
+
+    assert list(labels) == [1, 5]
 
 
 def test_labeled_scatter_preserves_sample_label_order():

--- a/tools/tabularlearner/test_multiclass_pr_auc_metric.py
+++ b/tools/tabularlearner/test_multiclass_pr_auc_metric.py
@@ -46,19 +46,48 @@ def _install_import_stubs():
 
 _install_import_stubs()
 
-from base_model_trainer import BaseModelTrainer, _add_pr_auc_metric_if_supported
-from classification_metrics import (
+
+def _load_tool_modules():
+    from base_model_trainer import _add_pr_auc_metric_if_supported, BaseModelTrainer
+    from classification_metrics import (
+        labels_in_metric_order,
+        labels_in_sample_order,
+        weighted_ovr_pr_auc,
+    )
+    from feature_importance import FeatureImportanceAnalyzer
+    from pycaret_classification import (
+        _should_skip_pycaret_plot,
+        ClassificationModelTrainer,
+    )
+    from pycaret_predict import _add_pr_auc_metric_if_supported as add_predict_pr_auc
+    from pycaret_regression import RegressionModelTrainer
+
+    return (
+        _add_pr_auc_metric_if_supported,
+        BaseModelTrainer,
+        labels_in_metric_order,
+        labels_in_sample_order,
+        weighted_ovr_pr_auc,
+        FeatureImportanceAnalyzer,
+        _should_skip_pycaret_plot,
+        ClassificationModelTrainer,
+        add_predict_pr_auc,
+        RegressionModelTrainer,
+    )
+
+
+(
+    _add_pr_auc_metric_if_supported,
+    BaseModelTrainer,
     labels_in_metric_order,
     labels_in_sample_order,
     weighted_ovr_pr_auc,
-)
-from feature_importance import FeatureImportanceAnalyzer
-from pycaret_classification import (
-    ClassificationModelTrainer,
+    FeatureImportanceAnalyzer,
     _should_skip_pycaret_plot,
-)
-from pycaret_regression import RegressionModelTrainer
-from pycaret_predict import _add_pr_auc_metric_if_supported as add_predict_pr_auc
+    ClassificationModelTrainer,
+    add_predict_pr_auc,
+    RegressionModelTrainer,
+) = _load_tool_modules()
 
 
 class FakeModel:

--- a/tools/tabularlearner/test_multiclass_pr_auc_metric.py
+++ b/tools/tabularlearner/test_multiclass_pr_auc_metric.py
@@ -479,6 +479,70 @@ def test_tree_plot_failure_does_not_block_html_report(caplog):
     assert "Tree plots skipped: dot failed" in caplog.text
 
 
+def test_feature_importance_reuses_setup_experiment_without_is_setup(tmp_path):
+    class ConfiguredExperiment:
+        target_param = "AGE"
+        dataset = pd.DataFrame({"feature": [1, 2], "AGE": [None, None]})
+
+        def __init__(self):
+            self.setup_called = False
+
+        def get_config(self, key):
+            if key == "X_test_transformed":
+                return pd.DataFrame({"feature": [1, 2]})
+            raise KeyError(key)
+
+        def setup(self, *args, **kwargs):
+            self.setup_called = True
+            raise AssertionError("setup should not be called")
+
+    exp = ConfiguredExperiment()
+    analyzer = FeatureImportanceAnalyzer(
+        task_type="regression",
+        output_dir=str(tmp_path),
+        data=pd.DataFrame({"feature": [1, 2], "AGE": [10, 20]}),
+        target_col=2,
+        exp=exp,
+        best_model=object(),
+    )
+    calls = []
+    analyzer.save_tree_importance = lambda: calls.append("tree")
+    analyzer.save_shap_values = lambda: calls.append("shap")
+    analyzer.generate_html_report = lambda: "html"
+
+    assert analyzer.run() == "html"
+    assert calls == ["tree", "shap"]
+    assert exp.setup_called is False
+
+
+def test_feature_importance_setup_prefers_supplied_data_over_exp_dataset(tmp_path):
+    clean_data = pd.DataFrame({"feature": [1, 2], "AGE": [10, 20]})
+
+    class UnconfiguredExperiment:
+        target_param = "AGE"
+        dataset = pd.DataFrame({"feature": [1, 2], "AGE": [None, None]})
+        is_setup = False
+
+        def setup(self, data, **kwargs):
+            self.setup_data = data.copy()
+            self.setup_kwargs = kwargs
+
+    exp = UnconfiguredExperiment()
+    analyzer = FeatureImportanceAnalyzer(
+        task_type="regression",
+        output_dir=str(tmp_path),
+        data=clean_data,
+        target_col=2,
+        exp=exp,
+        best_model=object(),
+    )
+
+    analyzer.setup_pycaret()
+
+    assert exp.setup_data["AGE"].isna().sum() == 0
+    assert exp.setup_kwargs["target"] == "AGE"
+
+
 class FakeShapExplanation:
     def __init__(self, shape, selected=None):
         self.shape = shape

--- a/tools/tabularlearner/test_multiclass_pr_auc_metric.py
+++ b/tools/tabularlearner/test_multiclass_pr_auc_metric.py
@@ -2,6 +2,7 @@ import sys
 import types
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 
@@ -40,16 +41,30 @@ from pycaret_predict import _add_pr_auc_metric_if_supported as add_predict_pr_au
 
 
 class FakeModel:
+    classes_ = [1, 2, 3, 4, 5]
+
     def predict(self, X=None):
-        return []
+        n_rows = len(X) if X is not None else 0
+        return np.resize(np.asarray(self.classes_), n_rows)
+
+    def predict_proba(self, X=None):
+        n_rows = len(X) if X is not None else 0
+        proba = np.full((n_rows, len(self.classes_)), 0.05)
+        if n_rows:
+            proba[np.arange(n_rows), np.arange(n_rows) % len(self.classes_)] = 0.8
+        return proba
 
 
 class FakeExperiment:
-    def __init__(self, is_multiclass):
+    def __init__(self, is_multiclass, always_shape_error=False):
         self.is_multiclass = is_multiclass
+        self.always_shape_error = always_shape_error
         self.metric_added = False
         self.compare_kwargs = None
         self.predict_called = False
+        self.predict_kwargs = None
+        self.X_test = pd.DataFrame({"feature": range(10)})
+        self.y_test = pd.Series([1, 2, 3, 4, 5] * 2)
 
     def add_metric(self, **kwargs):
         self.metric_added = True
@@ -63,10 +78,20 @@ class FakeExperiment:
         return pd.DataFrame({"AUC": [0.75]})
 
     def predict_model(self, model, **kwargs):
-        if self.metric_added and self.is_multiclass:
-            raise ValueError("Shape of passed values is (60, 5), indices imply (60, 1)")
         self.predict_called = True
+        self.predict_kwargs = kwargs
+        if self.always_shape_error or (self.metric_added and self.is_multiclass):
+            raise ValueError("Shape of passed values is (60, 5), indices imply (60, 1)")
         return pd.DataFrame()
+
+    def get_config(self, key):
+        values = {
+            "X_test": self.X_test,
+            "X_test_transformed": self.X_test,
+            "y_test": self.y_test,
+            "y_test_transformed": self.y_test,
+        }
+        return values.get(key)
 
 
 def test_training_pr_auc_metric_is_skipped_for_multiclass():
@@ -104,6 +129,29 @@ def test_multiclass_train_model_does_not_register_pr_auc_before_predict_model(tm
     assert trainer.exp.metric_added is False
     assert trainer.exp.compare_kwargs["sort"] == "AUC"
     assert trainer.exp.predict_called is True
+    assert trainer.exp.predict_kwargs == {}
+
+
+def test_multiclass_shape_error_falls_back_to_gleam_test_metrics(tmp_path):
+    trainer = BaseModelTrainer(
+        input_file="unused.tsv",
+        target_col="1",
+        output_dir=str(tmp_path),
+        task_type="classification",
+        random_seed=42,
+        best_model_metric="AUC",
+        probability_threshold=0.7,
+    )
+    trainer.exp = FakeExperiment(is_multiclass=True, always_shape_error=True)
+
+    trainer.train_model()
+
+    assert trainer.exp.predict_called is True
+    assert trainer.exp.predict_kwargs == {}
+    assert "Accuracy" in trainer.test_result_df.columns
+    assert "ROC-AUC" in trainer.test_result_df.columns
+    assert "PR-AUC" in trainer.test_result_df.columns
+    assert len(trainer.test_result_df) == 1
 
 
 def test_predict_evaluator_pr_auc_metric_is_skipped_for_multiclass():

--- a/tools/tabularlearner/test_multiclass_pr_auc_metric.py
+++ b/tools/tabularlearner/test_multiclass_pr_auc_metric.py
@@ -543,6 +543,47 @@ def test_feature_importance_setup_prefers_supplied_data_over_exp_dataset(tmp_pat
     assert exp.setup_kwargs["target"] == "AGE"
 
 
+def test_tree_shap_explainer_does_not_pass_unsupported_n_jobs(monkeypatch):
+    import feature_importance
+
+    calls = []
+
+    def fake_tree_explainer(model, background, **kwargs):
+        calls.append(kwargs)
+        if "n_jobs" in kwargs:
+            raise TypeError("__init__() got an unexpected keyword argument 'n_jobs'")
+        return "explainer"
+
+    monkeypatch.setattr(
+        feature_importance.shap,
+        "TreeExplainer",
+        fake_tree_explainer,
+        raising=False,
+    )
+
+    class LGBMClassifier:
+        pass
+
+    analyzer = object.__new__(FeatureImportanceAnalyzer)
+    analyzer.task_type = "classification"
+
+    explainer, label, tree_based = analyzer._choose_shap_explainer(
+        LGBMClassifier(),
+        pd.DataFrame({"feature": [1, 2]}),
+        lambda X: X,
+    )
+
+    assert explainer == "explainer"
+    assert label == "tree_path_dependent"
+    assert tree_based is True
+    assert calls == [
+        {
+            "model_output": "raw",
+            "feature_perturbation": "tree_path_dependent",
+        }
+    ]
+
+
 class FakeShapExplanation:
     def __init__(self, shape, selected=None):
         self.shape = shape

--- a/tools/tabularlearner/test_multiclass_pr_auc_metric.py
+++ b/tools/tabularlearner/test_multiclass_pr_auc_metric.py
@@ -21,6 +21,10 @@ def _install_import_stubs():
     regression = sys.modules.setdefault(
         "pycaret.regression", types.ModuleType("pycaret.regression")
     )
+    utils = sys.modules.setdefault("pycaret.utils", types.ModuleType("pycaret.utils"))
+    generic = sys.modules.setdefault(
+        "pycaret.utils.generic", types.ModuleType("pycaret.utils.generic")
+    )
 
     class ClassificationExperiment:
         pass
@@ -28,15 +32,25 @@ def _install_import_stubs():
     class RegressionExperiment:
         pass
 
+    def get_label_encoder(*args, **kwargs):
+        return None
+
     classification.ClassificationExperiment = ClassificationExperiment
     regression.RegressionExperiment = RegressionExperiment
+    generic.get_label_encoder = get_label_encoder
     pycaret.classification = classification
     pycaret.regression = regression
+    pycaret.utils = utils
+    utils.generic = generic
 
 
 _install_import_stubs()
 
 from base_model_trainer import BaseModelTrainer, _add_pr_auc_metric_if_supported
+from pycaret_classification import (
+    ClassificationModelTrainer,
+    _should_skip_pycaret_plot,
+)
 from pycaret_predict import _add_pr_auc_metric_if_supported as add_predict_pr_auc
 
 
@@ -92,6 +106,19 @@ class FakeExperiment:
             "y_test_transformed": self.y_test,
         }
         return values.get(key)
+
+
+class FakePlotExperiment:
+    is_multiclass = True
+
+    def __init__(self):
+        self.plot_calls = []
+
+    def plot_model(self, model, plot, save=True, plot_kwargs=None):
+        self.plot_calls.append(plot)
+        if plot == "threshold":
+            raise AssertionError("threshold plot should be skipped for multiclass")
+        return f"{plot}.png"
 
 
 def test_training_pr_auc_metric_is_skipped_for_multiclass():
@@ -161,3 +188,18 @@ def test_predict_evaluator_pr_auc_metric_is_skipped_for_multiclass():
 
     assert added is False
     assert exp.metric_added is False
+
+
+def test_multiclass_threshold_plot_is_skipped():
+    exp = FakePlotExperiment()
+    trainer = object.__new__(ClassificationModelTrainer)
+    trainer.best_model = FakeModel()
+    trainer.exp = exp
+    trainer.plots = {}
+
+    trainer.generate_plots()
+
+    assert _should_skip_pycaret_plot("threshold", exp) is True
+    assert "threshold" not in exp.plot_calls
+    assert "threshold" not in trainer.plots
+    assert "auc" in exp.plot_calls

--- a/tools/tabularlearner/test_multiclass_pr_auc_metric.py
+++ b/tools/tabularlearner/test_multiclass_pr_auc_metric.py
@@ -69,6 +69,12 @@ class FakeModel:
         return proba
 
 
+class FakeModelWithoutProba:
+    def predict(self, X=None):
+        n_rows = len(X) if X is not None else 0
+        return np.resize(np.asarray([1, 2, 3, 4, 5]), n_rows)
+
+
 class FakeExperiment:
     def __init__(self, is_multiclass, always_shape_error=False):
         self.is_multiclass = is_multiclass
@@ -79,6 +85,9 @@ class FakeExperiment:
         self.predict_kwargs = None
         self.X_test = pd.DataFrame({"feature": range(10)})
         self.y_test = pd.Series([1, 2, 3, 4, 5] * 2)
+        self.X_test_transformed = self.X_test
+        self.y_test_transformed = self.y_test
+        self.pipeline = None
 
     def add_metric(self, **kwargs):
         self.metric_added = True
@@ -203,3 +212,44 @@ def test_multiclass_threshold_plot_is_skipped():
     assert "threshold" not in exp.plot_calls
     assert "threshold" not in trainer.plots
     assert "auc" in exp.plot_calls
+
+
+def test_multiclass_plot_generation_does_not_add_binary_proba_patch():
+    exp = FakePlotExperiment()
+    model = FakeModelWithoutProba()
+    trainer = object.__new__(ClassificationModelTrainer)
+    trainer.best_model = model
+    trainer.exp = exp
+    trainer.plots = {}
+
+    trainer.generate_plots()
+
+    assert not hasattr(model, "predict_proba")
+
+
+def test_multiclass_explainer_failure_keeps_custom_plots(monkeypatch):
+    explainerdashboard = types.ModuleType("explainerdashboard")
+
+    class RaisingClassifierExplainer:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("no multiclass probabilities")
+
+    explainerdashboard.ClassifierExplainer = RaisingClassifierExplainer
+    monkeypatch.setitem(sys.modules, "explainerdashboard", explainerdashboard)
+
+    exp = FakeExperiment(is_multiclass=True)
+    trainer = object.__new__(ClassificationModelTrainer)
+    trainer.best_model = FakeModelWithoutProba()
+    trainer.exp = exp
+    trainer.task_type = "classification"
+    trainer.target = "AGE"
+    trainer.test_data = None
+    trainer.random_seed = 42
+    trainer.plot_feature_names = []
+    trainer.explainer_plots = {}
+    trainer._limit_explainer_data = lambda X, y, **kwargs: (X, y)
+
+    trainer.generate_plots_explainer()
+
+    assert "class_report" in trainer.explainer_plots
+    assert "confusion_matrix" in trainer.explainer_plots

--- a/tools/tabularlearner/test_multiclass_pr_auc_metric.py
+++ b/tools/tabularlearner/test_multiclass_pr_auc_metric.py
@@ -418,6 +418,38 @@ def test_regression_permutation_importance_uses_supported_explainer_api(monkeypa
     assert {"kind": "permutation"} in calls
 
 
+def test_tree_plot_failure_does_not_block_html_report(caplog):
+    calls = []
+    trainer = object.__new__(BaseModelTrainer)
+    trainer.load_data = lambda: calls.append("load_data")
+    trainer.setup_pycaret = lambda: calls.append("setup_pycaret")
+    trainer.train_model = lambda: calls.append("train_model")
+    trainer.save_model = lambda: calls.append("save_model")
+    trainer.generate_plots = lambda: calls.append("generate_plots")
+    trainer.generate_plots_explainer = lambda: calls.append("generate_plots_explainer")
+    trainer.save_html_report = lambda: calls.append("save_html_report")
+
+    def _raise_tree_error():
+        calls.append("generate_tree_plots")
+        raise RuntimeError("dot failed")
+
+    trainer.generate_tree_plots = _raise_tree_error
+
+    BaseModelTrainer.run(trainer)
+
+    assert calls == [
+        "load_data",
+        "setup_pycaret",
+        "train_model",
+        "save_model",
+        "generate_plots",
+        "generate_plots_explainer",
+        "generate_tree_plots",
+        "save_html_report",
+    ]
+    assert "Tree plots skipped: dot failed" in caplog.text
+
+
 class FakeShapExplanation:
     def __init__(self, shape, selected=None):
         self.shape = shape


### PR DESCRIPTION
# Fixes

- Fixes multiclass PR-AUC/ROC-AUC metric handling so probability columns are matched to `model.classes_`.
- Skips unsupported PyCaret multiclass threshold plots.
- Adds fallback held-out test metrics when `PyCaret predict_model()` crashes on multiclass probability shape handling.
- Preserves sample label order in report labels, confusion matrices, RadViz, t-SNE, and multiclass ROC/PR plots.
- Fixes SHAP report logic for binary, multiclass, and regression.
- Makes `generate_tree_plots()` non-fatal so dtreeviz/Graphviz SVG failures do not prevent final outputs from being saved.

## Details

- Added shared classification metric helpers in `classification_metrics.py`.
- Binary classification now plots SHAP for the positive class only.
- Multiclass classification now creates per-class SHAP summaries in model class order.
- Regression SHAP now produces a single summary plot and uses the supported permutation importance API.
- Custom SHAP now computes against the full transformed feature matrix and only caps rows/displayed features, avoiding invalid model inputs.
- Tree visualization failures are now logged as warnings and skipped, allowing `comparison_result.html`, `best_model.csv`, `comparison_results.csv`, and other completed outputs to be written.