### PR TITLE
Add automatic threshold selection to Tabular Learner

### DIFF
--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1135,12 +1135,12 @@ class BaseModelTrainer:
             return []
 
         rows = [
-            ["Decision threshold (Test)", threshold_display],
             ["Threshold source", metadata.get("threshold_source", "Unknown")],
             [
                 "Threshold optimization metric",
                 metadata.get("threshold_metric", "Not used"),
             ],
+            ["Decision threshold (Test)", threshold_display],
         ]
         score_display = self._format_threshold_value(
             metadata.get("threshold_score")
@@ -2289,9 +2289,16 @@ class BaseModelTrainer:
             all_params["probability_threshold"] = (
                 self.probability_threshold
             )
+        metric_label = self._best_model_metric_used or getattr(
+            self.exp, "_fold_metric", None
+        )
+        setup_rows = []
+        if metric_label:
+            setup_rows.append(["Best Model Metric", metric_label])
+
         display_keys = [
             "Target",
-            "Session ID",
+            "Random Seed",
             "Train Size",
             "Normalize",
             "Feature Selection",
@@ -2306,17 +2313,13 @@ class BaseModelTrainer:
             display_keys.extend([
                 "Fix Imbalance",
             ])
-        setup_rows = []
         for key in display_keys:
             pk = key.lower().replace(" ", "_")
+            if key == "Random Seed":
+                pk = "session_id"
             v = all_params.get(pk)
             if key == "Train Size":
-                frac = (
-                    float(v)
-                    if v is not None
-                    else (n_train / total_rows if total_rows else 0)
-                )
-                dv = f"{frac:.2f} ({n_train} rows)"
+                dv = f"{n_train} rows"
             elif key in {
                 "Normalize",
                 "Feature Selection",
@@ -2348,11 +2351,6 @@ class BaseModelTrainer:
                 dv = v if v is not None else "None"
             setup_rows.append([key, dv])
         setup_rows.extend(self._threshold_report_rows())
-        metric_label = self._best_model_metric_used or getattr(
-            self.exp, "_fold_metric", None
-        )
-        if metric_label:
-            setup_rows.append(["Best Model Metric", metric_label])
         adjustment = getattr(self, "cv_fold_adjustment", None)
         if adjustment:
             setup_rows.append([
@@ -2469,7 +2467,10 @@ class BaseModelTrainer:
             cv_fold_allocation_html
             + f"<h2>{summary_heading}</h2>"
             + '<div class="table-wrapper">'
-            + val_df.to_html(index=False, classes="table sortable")
+            + val_df.to_html(
+                index=False,
+                classes=["table", "sortable", "table-model-comparison"],
+            )
             + "</div>"
             + f"<p class='report-footnote'>{model_selection_note}</p>"
         )
@@ -2829,7 +2830,6 @@ class BaseModelTrainer:
         from sklearn.ensemble import (
             RandomForestClassifier, RandomForestRegressor
         )
-        from xgboost import XGBClassifier, XGBRegressor
 
         LOG.info("Generating tree plots")
         X_test = self.exp.X_test_transformed.copy()
@@ -2839,10 +2839,12 @@ class BaseModelTrainer:
             self.best_model, (RandomForestClassifier, RandomForestRegressor)
         ):
             n_trees = self.best_model.n_estimators
-        elif isinstance(self.best_model, (XGBClassifier, XGBRegressor)):
-            n_trees = len(self.best_model.get_booster().get_dump())
         else:
-            LOG.warning("Tree plots not supported for this model type.")
+            LOG.info(
+                "Skipping decision-tree explainer plots for unsupported model "
+                "type %s.",
+                type(self.best_model).__name__,
+            )
             return
 
         explainer = RandomForestExplainer(self.best_model, X_test, y_test)

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1142,14 +1142,6 @@ class BaseModelTrainer:
             ],
             ["Decision threshold (Test)", threshold_display],
         ]
-        score_display = self._format_threshold_value(
-            metadata.get("threshold_score")
-        )
-        if score_display is not None:
-            rows.append([
-                "Threshold optimization score",
-                score_display,
-            ])
         return rows
 
     def save_model(self):
@@ -1300,10 +1292,8 @@ class BaseModelTrainer:
         else:
             y_test = y_test_cfg
 
-        validation_enabled = getattr(self, "cross_validation", None) is not False
-        train_label = "Training / CV Pool" if validation_enabled else "Train"
         split_map = {
-            train_label: _safe_series(y_train_series),
+            "Training": _safe_series(y_train_series),
             "Test": _safe_series(y_test),
         }
         split_map = {
@@ -1342,21 +1332,13 @@ class BaseModelTrainer:
                 if cnt is None or total is None:
                     cell = "—"
                 else:
-                    pct = (cnt / total * 100) if total else 0
-                    cell = f"{cnt} ({pct:.1f}%)"
+                    cell = str(cnt)
                 row.append(cell)
             rows.append(row)
 
         df = pd.DataFrame(rows, columns=["Label", *split_map.keys()])
         df.sort_values("Label", inplace=True)
 
-        note = (
-            "<p class='report-footnote'>Note: The Training / CV Pool column "
-            "shows the total samples used for training and validation rather "
-            "than separate fixed train and validation count columns.</p>"
-            if validation_enabled
-            else ""
-        )
         return (
             "<h2>Dataset Overview</h2>"
             + '<div class="table-wrapper">'
@@ -1365,7 +1347,6 @@ class BaseModelTrainer:
                 classes=["table", "sortable", "table-dataset-overview"],
             )
             + "</div>"
-            + note
         )
 
     def _predict_with_thresholds(self, X, y_true):
@@ -2155,13 +2136,6 @@ class BaseModelTrainer:
             rows.append(row)
 
         df = pd.DataFrame(rows, columns=columns)
-        note = (
-            "Note: Train and Test metrics are computed by scoring the selected "
-            "best model on the training/CV pool and held-out test set. These "
-            "values can differ from PyCaret's candidate-model table."
-            if validation_enabled
-            else ""
-        )
         return (
             "<h2>Best Model Performance</h2>"
             + '<div class="table-wrapper">'
@@ -2170,7 +2144,6 @@ class BaseModelTrainer:
                 classes=["table", "sortable", "table-perf-summary"],
             )
             + "</div>"
-            + (f"<p class='report-footnote'>{note}</p>" if note else "")
         )
 
     @staticmethod

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1144,6 +1144,28 @@ class BaseModelTrainer:
         ]
         return rows
 
+    def _threshold_plot_note_html(self):
+        if self.task_type != "classification":
+            return ""
+        if getattr(self.exp, "is_multiclass", False):
+            return ""
+
+        metadata = self.threshold_metadata or {}
+        source = str(metadata.get("threshold_source", "")).lower()
+        if "optimized" not in source:
+            return ""
+
+        return (
+            "<p class='report-footnote'>Note: The threshold marker shown in "
+            "the plot can differ slightly from the automatically selected "
+            "decision threshold because the plot and the optimizer may use "
+            "different threshold grids, rounding, or tie-breaking among "
+            "near-equivalent metric values. The test results use the selected "
+            "Decision threshold (Test) reported in Experiment and Data "
+            "Parameters, so this visual difference does not change the final "
+            "test scoring.</p>"
+        )
+
     def save_model(self):
         hdf5_path = Path(self.output_dir) / "pycaret_model.h5"
         with h5py.File(hdf5_path, "w") as f:
@@ -2511,6 +2533,11 @@ class BaseModelTrainer:
                     "<hr>"
                     f"<h2>{title}</h2>"
                     + add_plot_to_html(fig)
+                    + (
+                        self._threshold_plot_note_html()
+                        if name == "threshold"
+                        else ""
+                    )
                 )
             elif name in self.plots:
                 summary_html += "<hr>"
@@ -2525,6 +2552,11 @@ class BaseModelTrainer:
                     'style="max-width:90%;max-height:600px;'
                     'border:1px solid #ddd;"/>'
                     "</div>"
+                    + (
+                        self._threshold_plot_note_html()
+                        if name == "threshold"
+                        else ""
+                    )
                 )
 
         # — Test Summary —

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -158,6 +158,7 @@ class BaseModelTrainer:
             )
         self.imputed_training_data = None
         self._best_model_metric_used = None
+        self.threshold_metadata = None
         self.cv_fold_adjustment = None
         self.setup_params = {}
         self.test_file = test_file
@@ -171,9 +172,11 @@ class BaseModelTrainer:
         # Warn about irrelevant kwargs for the task type
         if self.task_type == "regression" and (
             "probability_threshold" in self.user_kwargs
+            or "threshold_mode" in self.user_kwargs
+            or "threshold_metric" in self.user_kwargs
         ):
             LOG.warning(
-                "probability_threshold is ignored for regression tasks."
+                "Classification threshold settings are ignored for regression tasks."
             )
 
         LOG.info(f"Model kwargs: {self.__dict__}")
@@ -787,10 +790,17 @@ class BaseModelTrainer:
             self.results.rename(
                 columns={"PR-AUC-Weighted": "PR-AUC"}, inplace=True
             )
+            self._configure_decision_threshold()
 
         prob_thresh = getattr(self, "probability_threshold", None)
-        if self.task_type == "classification" and (
-            prob_thresh is not None
+        is_multiclass = (
+            self.task_type == "classification"
+            and getattr(self.exp, "is_multiclass", False)
+        )
+        if (
+            self.task_type == "classification"
+            and prob_thresh is not None
+            and not is_multiclass
         ):
             _ = self.exp.predict_model(
                 self.best_model, probability_threshold=prob_thresh
@@ -807,6 +817,121 @@ class BaseModelTrainer:
                 columns={"PR-AUC-Weighted": "PR-AUC"}, inplace=True
             )
             self._replace_test_pr_auc()
+
+    def _configure_decision_threshold(self):
+        """
+        Configure the binary classification decision threshold before final
+        held-out scoring, report metrics, plot markers, and model persistence.
+        """
+        if self.task_type != "classification":
+            return
+
+        if getattr(self.exp, "is_multiclass", False):
+            self.probability_threshold = None
+            self.threshold_metadata = {
+                "threshold": None,
+                "threshold_source": "Not used (multiclass classification)",
+                "threshold_metric": "Not used",
+            }
+            return
+
+        mode = str(getattr(self, "threshold_mode", "auto") or "auto").lower()
+        if mode == "manual":
+            threshold = getattr(self, "probability_threshold", None)
+            if threshold is None:
+                threshold = 0.5
+            threshold = float(threshold)
+            self._validate_probability_threshold(threshold)
+            self.probability_threshold = threshold
+            self.threshold_metadata = {
+                "threshold": threshold,
+                "threshold_source": "Manual",
+                "threshold_metric": "Not used",
+            }
+            return
+
+        metric = str(getattr(self, "threshold_metric", "F1") or "F1")
+        try:
+            optimized_model = self.exp.optimize_threshold(
+                self.best_model,
+                optimize=metric,
+                verbose=False,
+            )
+            threshold = getattr(optimized_model, "probability_threshold", None)
+            if threshold is None:
+                raise ValueError(
+                    "PyCaret did not return an optimized probability threshold."
+                )
+            threshold = float(threshold)
+            self._validate_probability_threshold(threshold)
+            self.best_model = optimized_model
+            self.probability_threshold = threshold
+            self.threshold_metadata = {
+                "threshold": threshold,
+                "threshold_source": "Optimized on validation split",
+                "threshold_metric": metric,
+            }
+            LOG.info(
+                "Optimized binary decision threshold using %s: %.6f",
+                metric,
+                threshold,
+            )
+        except Exception as exc:
+            fallback = 0.5
+            self.probability_threshold = fallback
+            self.threshold_metadata = {
+                "threshold": fallback,
+                "threshold_source": (
+                    "Default 0.5 (automatic optimization unavailable)"
+                ),
+                "threshold_metric": metric,
+                "threshold_reason": str(exc),
+            }
+            LOG.warning(
+                "Could not optimize binary decision threshold with PyCaret; "
+                "using default threshold %.1f: %s",
+                fallback,
+                exc,
+            )
+
+    @staticmethod
+    def _validate_probability_threshold(threshold):
+        if threshold < 0.0 or threshold > 1.0:
+            raise ValueError(
+                "Probability threshold must be between 0.0 and 1.0."
+            )
+
+    @staticmethod
+    def _format_threshold_value(threshold):
+        if threshold is None:
+            return None
+        try:
+            return f"{float(threshold):.3f}"
+        except Exception:
+            return str(threshold)
+
+    def _threshold_report_rows(self):
+        if self.task_type != "classification":
+            return []
+        if getattr(self.exp, "is_multiclass", False):
+            return []
+
+        metadata = self.threshold_metadata or {}
+        threshold = metadata.get(
+            "threshold", getattr(self, "probability_threshold", None)
+        )
+        threshold_display = self._format_threshold_value(threshold)
+        if threshold_display is None:
+            return []
+
+        return [
+            ["Decision threshold (Test)", threshold_display],
+            ["Threshold source", metadata.get("threshold_source", "Unknown")],
+            [
+                "Threshold optimization metric",
+                metadata.get("threshold_metric", "Not used"),
+            ],
+        ]
 
     def save_model(self):
         hdf5_path = Path(self.output_dir) / "pycaret_model.h5"
@@ -1958,7 +2083,6 @@ class BaseModelTrainer:
         if self.task_type == "classification":
             display_keys.extend([
                 "Fix Imbalance",
-                "Probability Threshold",
             ])
         setup_rows = []
         for key in display_keys:
@@ -1998,11 +2122,10 @@ class BaseModelTrainer:
                 dv = ", ".join(map(str, v)) if isinstance(
                     v, (list, tuple)
                 ) else "None"
-            elif key == "Probability Threshold":
-                dv = f"{v:.2f}" if v is not None else "0.5"
             else:
                 dv = v if v is not None else "None"
             setup_rows.append([key, dv])
+        setup_rows.extend(self._threshold_report_rows())
         metric_label = self._best_model_metric_used or getattr(
             self.exp, "_fold_metric", None
         )

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1,4 +1,5 @@
 import base64
+import inspect
 import logging
 import tempfile
 from pathlib import Path
@@ -852,15 +853,49 @@ class BaseModelTrainer:
 
         metric = str(getattr(self, "threshold_metric", "F1") or "F1")
         try:
-            optimized_model = self.exp.optimize_threshold(
+            optimize_kwargs = {"optimize": metric, "return_data": True}
+            try:
+                optimize_signature = inspect.signature(
+                    self.exp.optimize_threshold
+                )
+                if "verbose" in optimize_signature.parameters:
+                    optimize_kwargs["verbose"] = False
+            except (TypeError, ValueError):
+                pass
+
+            optimized_result = self.exp.optimize_threshold(
                 self.best_model,
-                optimize=metric,
-                verbose=False,
+                **optimize_kwargs,
             )
-            threshold = getattr(optimized_model, "probability_threshold", None)
+            threshold_data = None
+            optimized_model = optimized_result
+            if isinstance(optimized_result, tuple):
+                threshold_data = next(
+                    (
+                        item
+                        for item in optimized_result
+                        if isinstance(item, pd.DataFrame)
+                    ),
+                    None,
+                )
+                optimized_model = next(
+                    (
+                        item
+                        for item in optimized_result
+                        if not isinstance(item, pd.DataFrame)
+                    ),
+                    optimized_result[-1],
+                )
+
+            threshold = self._extract_optimized_threshold(
+                optimized_model,
+                threshold_data,
+                metric,
+            )
             if threshold is None:
                 raise ValueError(
-                    "PyCaret did not return an optimized probability threshold."
+                    "PyCaret did not return an optimized probability threshold "
+                    "or threshold search table."
                 )
             threshold = float(threshold)
             self._validate_probability_threshold(threshold)
@@ -893,6 +928,34 @@ class BaseModelTrainer:
                 fallback,
                 exc,
             )
+
+    @staticmethod
+    def _extract_optimized_threshold(optimized_model, threshold_data, metric):
+        threshold = getattr(optimized_model, "probability_threshold", None)
+        if threshold is not None:
+            return threshold
+
+        if threshold_data is None or threshold_data.empty:
+            return None
+        if "probability_threshold" not in threshold_data.columns:
+            return None
+
+        metric_df = threshold_data.copy()
+        if "variable" in metric_df.columns and "value" in metric_df.columns:
+            metric_name = str(metric).lower()
+            metric_df = metric_df[
+                metric_df["variable"].astype(str).str.lower() == metric_name
+            ]
+            if metric_df.empty:
+                return None
+            best_idx = metric_df["value"].astype(float).idxmax()
+            return metric_df.loc[best_idx, "probability_threshold"]
+
+        if metric in metric_df.columns:
+            best_idx = metric_df[metric].astype(float).idxmax()
+            return metric_df.loc[best_idx, "probability_threshold"]
+
+        return None
 
     @staticmethod
     def _validate_probability_threshold(threshold):

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1160,10 +1160,7 @@ class BaseModelTrainer:
             "the plot can differ slightly from the automatically selected "
             "decision threshold because the plot and the optimizer may use "
             "different threshold grids, rounding, or tie-breaking among "
-            "near-equivalent metric values. The test results use the selected "
-            "Decision threshold (Test) reported in Experiment and Data "
-            "Parameters, so this visual difference does not change the final "
-            "test scoring.</p>"
+            "near-equivalent metric values.</p>"
         )
 
     def save_model(self):

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -2697,7 +2697,7 @@ class BaseModelTrainer:
         if getattr(self, "explainer_dashboard_importance_skipped", False):
             cap_rows.append((
                 "ExplainerDashboard SHAP/permutation importance",
-                "Skipped; custom capped SHAP is shown instead",
+                "Skipped to avoid duplicate SHAP computation",
             ))
         if getattr(self, "polynomial_features", False):
             cap_rows.append((

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1179,10 +1179,7 @@ class BaseModelTrainer:
             "the plot can differ slightly from the automatically selected "
             "decision threshold because the plot and the optimizer may use "
             "different threshold grids, rounding, or tie-breaking among "
-            "near-equivalent metric values. The test results use the selected "
-            "Decision threshold (Test) reported in Experiment and Data "
-            "Parameters, so this visual difference does not change the final "
-            "test scoring.</p>"
+            "near-equivalent metric values.</p>"
         )
 
     def save_model(self):

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -2295,7 +2295,6 @@ class BaseModelTrainer:
             n_train = getattr(
                 self.exp, "X_train_transformed", pd.DataFrame()
             ).shape[0]
-        total_rows = self.data.shape[0]
 
         # 3) Build setup parameters table
         all_params = self.setup_params.copy()

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -1,5 +1,4 @@
 import base64
-import inspect
 import logging
 import tempfile
 from pathlib import Path
@@ -14,6 +13,7 @@ from feature_importance import FeatureImportanceAnalyzer
 from sklearn.metrics import (
     accuracy_score,
     auc,
+    cohen_kappa_score,
     confusion_matrix,
     f1_score,
     matthews_corrcoef,
@@ -160,6 +160,7 @@ class BaseModelTrainer:
         self.imputed_training_data = None
         self._best_model_metric_used = None
         self.threshold_metadata = None
+        self._threshold_cv_predictions = None
         self.cv_fold_adjustment = None
         self.setup_params = {}
         self.test_file = test_file
@@ -844,6 +845,7 @@ class BaseModelTrainer:
             threshold = float(threshold)
             self._validate_probability_threshold(threshold)
             self.probability_threshold = threshold
+            self._threshold_cv_predictions = None
             self.threshold_metadata = {
                 "threshold": threshold,
                 "threshold_source": "Manual",
@@ -853,67 +855,31 @@ class BaseModelTrainer:
 
         metric = str(getattr(self, "threshold_metric", "F1") or "F1")
         try:
-            optimize_kwargs = {"optimize": metric, "return_data": True}
-            try:
-                optimize_signature = inspect.signature(
-                    self.exp.optimize_threshold
-                )
-                if "verbose" in optimize_signature.parameters:
-                    optimize_kwargs["verbose"] = False
-            except (TypeError, ValueError):
-                pass
-
-            optimized_result = self.exp.optimize_threshold(
-                self.best_model,
-                **optimize_kwargs,
-            )
-            threshold_data = None
-            optimized_model = optimized_result
-            if isinstance(optimized_result, tuple):
-                threshold_data = next(
-                    (
-                        item
-                        for item in optimized_result
-                        if isinstance(item, pd.DataFrame)
-                    ),
-                    None,
-                )
-                optimized_model = next(
-                    (
-                        item
-                        for item in optimized_result
-                        if not isinstance(item, pd.DataFrame)
-                    ),
-                    optimized_result[-1],
-                )
-
-            threshold = self._extract_optimized_threshold(
-                optimized_model,
-                threshold_data,
-                metric,
-            )
-            if threshold is None:
-                raise ValueError(
-                    "PyCaret did not return an optimized probability threshold "
-                    "or threshold search table."
-                )
-            threshold = float(threshold)
+            result = self._optimize_threshold_from_training_cv(metric)
+            threshold = float(result["threshold"])
             self._validate_probability_threshold(threshold)
-            self.best_model = optimized_model
             self.probability_threshold = threshold
+            self._threshold_cv_predictions = result.get("predictions")
             self.threshold_metadata = {
                 "threshold": threshold,
-                "threshold_source": "Optimized on validation split",
+                "threshold_source": (
+                    "Optimized on cross-validated training predictions"
+                ),
                 "threshold_metric": metric,
+                "threshold_score": result["score"],
+                "threshold_candidates": result["n_candidates"],
             }
             LOG.info(
-                "Optimized binary decision threshold using %s: %.6f",
+                "Optimized binary decision threshold using %s: %.6f "
+                "(validation score %.6f)",
                 metric,
                 threshold,
+                result["score"],
             )
         except Exception as exc:
             fallback = 0.5
             self.probability_threshold = fallback
+            self._threshold_cv_predictions = None
             self.threshold_metadata = {
                 "threshold": fallback,
                 "threshold_source": (
@@ -923,38 +889,219 @@ class BaseModelTrainer:
                 "threshold_reason": str(exc),
             }
             LOG.warning(
-                "Could not optimize binary decision threshold with PyCaret; "
+                "Could not optimize binary decision threshold; "
                 "using default threshold %.1f: %s",
                 fallback,
                 exc,
             )
 
+    def _get_pycaret_config(self, keys):
+        for key in keys:
+            try:
+                val = self.exp.get_config(key)
+            except Exception:
+                val = getattr(self.exp, key, None)
+            if val is not None:
+                return val
+        return None
+
+    def _optimize_threshold_from_training_cv(self, metric):
+        """
+        Select a binary classification threshold from out-of-fold training
+        probabilities. The external/held-out test set is not used.
+        """
+        if getattr(self, "cross_validation", None) is False:
+            raise ValueError(
+                "Automatic threshold optimization requires cross-validation."
+            )
+
+        try:
+            from sklearn.model_selection import cross_val_predict
+        except Exception as exc:
+            raise ValueError(f"cross_val_predict unavailable: {exc}") from exc
+
+        X_train = self._get_pycaret_config(["X_train_transformed", "X_train"])
+        y_train = self._get_pycaret_config(["y_train_transformed", "y_train"])
+        if X_train is None or y_train is None:
+            raise ValueError(
+                "Training data unavailable for threshold optimization."
+            )
+
+        y_series = pd.Series(y_train).reset_index(drop=True)
+        if y_series.empty:
+            raise ValueError("Training labels are empty.")
+
+        X_df = pd.DataFrame(X_train).reset_index(drop=True)
+        if len(X_df) != len(y_series):
+            X_df = X_df.iloc[: len(y_series)].reset_index(drop=True)
+
+        cv_gen = self._get_cv_generator(y_series)
+        if cv_gen is None:
+            raise ValueError("Cross-validation splitter unavailable.")
+
+        cv_groups = getattr(self, "sample_id_series", None)
+        if cv_groups is not None:
+            cv_groups = pd.Series(cv_groups).reset_index(drop=True)
+            if len(cv_groups) != len(y_series):
+                LOG.warning(
+                    "Skipping group labels for threshold optimization because "
+                    "group count (%s) does not match training rows (%s).",
+                    len(cv_groups),
+                    len(y_series),
+                )
+                cv_groups = None
+
+        classes = list(getattr(self.best_model, "classes_", []))
+        if not classes:
+            classes = pd.unique(y_series).tolist()
+            try:
+                classes = sorted(classes)
+            except Exception:
+                pass
+        if len(classes) != 2:
+            raise ValueError(
+                "Automatic threshold optimization only supports binary classification."
+            )
+
+        try:
+            pos_idx = classes.index(1)
+        except Exception:
+            pos_idx = 1
+        pos_idx = min(pos_idx, len(classes) - 1)
+        pos_label = classes[pos_idx]
+        neg_label = classes[1 - pos_idx]
+
+        cv_predict_kwargs = {
+            "cv": cv_gen,
+            "method": "predict_proba",
+            "n_jobs": getattr(self, "n_jobs", None),
+        }
+        if cv_groups is not None:
+            cv_predict_kwargs["groups"] = cv_groups
+
+        try:
+            proba = cross_val_predict(
+                self.best_model,
+                X_df,
+                y_series,
+                **cv_predict_kwargs,
+            )
+        except Exception as exc:
+            raise ValueError(
+                f"Could not compute cross-validated probabilities: {exc}"
+            ) from exc
+
+        scores = np.asarray(proba)
+        if scores.ndim != 2 or scores.shape[1] < 2:
+            raise ValueError(
+                "Cross-validated probabilities are not available for both classes."
+            )
+        pos_scores = scores[:, min(pos_idx, scores.shape[1] - 1)]
+
+        finite_scores = pos_scores[np.isfinite(pos_scores)]
+        if finite_scores.size == 0:
+            raise ValueError("Cross-validated probabilities are all non-finite.")
+        finite_mask = np.isfinite(pos_scores)
+        if not finite_mask.all():
+            y_series = y_series[finite_mask].reset_index(drop=True)
+            pos_scores = pos_scores[finite_mask]
+
+        thresholds = np.unique(np.concatenate(([0.0, 1.0], finite_scores)))
+        metric_key = self._normalize_threshold_metric(metric)
+        candidates = []
+        for threshold in thresholds:
+            y_pred = np.where(pos_scores >= threshold, pos_label, neg_label)
+            score = self._score_threshold_metric(
+                y_series,
+                pd.Series(y_pred),
+                metric_key,
+                pos_label,
+            )
+            if score is None or not np.isfinite(score):
+                continue
+            candidates.append((float(threshold), float(score)))
+
+        if not candidates:
+            raise ValueError(
+                f"No valid threshold candidates for metric {metric}."
+            )
+
+        best_threshold, best_score = max(
+            candidates,
+            key=lambda item: (
+                item[1],
+                -abs(item[0] - 0.5),
+                -item[0],
+            ),
+        )
+        best_pred = np.where(pos_scores >= best_threshold, pos_label, neg_label)
+        return {
+            "threshold": best_threshold,
+            "score": best_score,
+            "n_candidates": len(candidates),
+            "predictions": {
+                "y_true": y_series,
+                "y_pred": pd.Series(best_pred).reset_index(drop=True),
+                "y_scores": pos_scores,
+                "pos_label": pos_label,
+                "neg_label": neg_label,
+                "classes": classes,
+            },
+        }
+
     @staticmethod
-    def _extract_optimized_threshold(optimized_model, threshold_data, metric):
-        threshold = getattr(optimized_model, "probability_threshold", None)
-        if threshold is not None:
-            return threshold
+    def _normalize_threshold_metric(metric):
+        normalized = str(metric or "F1").strip().lower()
+        aliases = {
+            "f1": "f1",
+            "f1-score": "f1",
+            "f1_score": "f1",
+            "accuracy": "accuracy",
+            "precision": "precision",
+            "recall": "recall",
+            "kappa": "kappa",
+            "cohen's kappa": "kappa",
+            "cohens kappa": "kappa",
+            "mcc": "mcc",
+            "matthews correlation coefficient": "mcc",
+        }
+        if normalized not in aliases:
+            raise ValueError(
+                "Unsupported threshold metric "
+                f"'{metric}'. Use F1, Accuracy, Precision, Recall, Kappa, "
+                "or MCC."
+            )
+        return aliases[normalized]
 
-        if threshold_data is None or threshold_data.empty:
-            return None
-        if "probability_threshold" not in threshold_data.columns:
-            return None
-
-        metric_df = threshold_data.copy()
-        if "variable" in metric_df.columns and "value" in metric_df.columns:
-            metric_name = str(metric).lower()
-            metric_df = metric_df[
-                metric_df["variable"].astype(str).str.lower() == metric_name
-            ]
-            if metric_df.empty:
-                return None
-            best_idx = metric_df["value"].astype(float).idxmax()
-            return metric_df.loc[best_idx, "probability_threshold"]
-
-        if metric in metric_df.columns:
-            best_idx = metric_df[metric].astype(float).idxmax()
-            return metric_df.loc[best_idx, "probability_threshold"]
-
+    @staticmethod
+    def _score_threshold_metric(y_true, y_pred, metric_key, pos_label):
+        if metric_key == "accuracy":
+            return accuracy_score(y_true, y_pred)
+        if metric_key == "precision":
+            return precision_score(
+                y_true,
+                y_pred,
+                pos_label=pos_label,
+                zero_division=0,
+            )
+        if metric_key == "recall":
+            return recall_score(
+                y_true,
+                y_pred,
+                pos_label=pos_label,
+                zero_division=0,
+            )
+        if metric_key == "f1":
+            return f1_score(
+                y_true,
+                y_pred,
+                pos_label=pos_label,
+                zero_division=0,
+            )
+        if metric_key == "kappa":
+            return cohen_kappa_score(y_true, y_pred)
+        if metric_key == "mcc":
+            return matthews_corrcoef(y_true, y_pred)
         return None
 
     @staticmethod
@@ -987,7 +1134,7 @@ class BaseModelTrainer:
         if threshold_display is None:
             return []
 
-        return [
+        rows = [
             ["Decision threshold (Test)", threshold_display],
             ["Threshold source", metadata.get("threshold_source", "Unknown")],
             [
@@ -995,6 +1142,15 @@ class BaseModelTrainer:
                 metadata.get("threshold_metric", "Not used"),
             ],
         ]
+        score_display = self._format_threshold_value(
+            metadata.get("threshold_score")
+        )
+        if score_display is not None:
+            rows.append([
+                "Threshold optimization score",
+                score_display,
+            ])
+        return rows
 
     def save_model(self):
         hdf5_path = Path(self.output_dir) / "pycaret_model.h5"
@@ -1553,6 +1709,9 @@ class BaseModelTrainer:
             return None
         if getattr(self, "cross_validation", None) is False:
             return None
+        cached = getattr(self, "_threshold_cv_predictions", None)
+        if cached is not None:
+            return cached
         if X is None or y is None:
             return None
 

--- a/tools/tabularlearner/base_model_trainer.py
+++ b/tools/tabularlearner/base_model_trainer.py
@@ -108,6 +108,30 @@ def pr_auc_curve_score(y_true, y_score):
     return _weighted_ovr_pr_auc(y_true, y_score)
 
 
+def _add_pr_auc_metric_if_supported(exp):
+    """
+    Register PyCaret's custom PR-AUC metric only for binary classification.
+
+    PyCaret 3.3.2 can pass multiclass probability matrices through a
+    single-column prediction-score path during predict_model(), which raises
+    a DataFrame shape error. Multiclass PR-AUC is still computed later by the
+    report code from the model's probability matrix.
+    """
+    if getattr(exp, "is_multiclass", False):
+        LOG.info(
+            "Skipping PyCaret custom PR-AUC metric for multiclass "
+            "classification; report PR-AUC will be computed separately."
+        )
+        return False
+    exp.add_metric(
+        id="PR-AUC",
+        name="PR-AUC",
+        target="pred_proba",
+        score_func=pr_auc_curve_score,
+    )
+    return True
+
+
 class BaseModelTrainer:
     def __init__(
         self,
@@ -738,12 +762,7 @@ class BaseModelTrainer:
     def train_model(self):
         LOG.info("Training and selecting the best model")
         if self.task_type == "classification":
-            self.exp.add_metric(
-                id="PR-AUC",
-                name="PR-AUC",
-                target="pred_proba",
-                score_func=pr_auc_curve_score,
-            )
+            _add_pr_auc_metric_if_supported(self.exp)
         # Build arguments for compare_models()
         compare_kwargs = {}
         if getattr(self, "models", None):
@@ -794,23 +813,7 @@ class BaseModelTrainer:
             )
             self._configure_decision_threshold()
 
-        prob_thresh = getattr(self, "probability_threshold", None)
-        is_multiclass = (
-            self.task_type == "classification"
-            and getattr(self.exp, "is_multiclass", False)
-        )
-        if (
-            self.task_type == "classification"
-            and prob_thresh is not None
-            and not is_multiclass
-        ):
-            _ = self.exp.predict_model(
-                self.best_model, probability_threshold=prob_thresh
-            )
-        else:
-            _ = self.exp.predict_model(self.best_model)
-
-        self.test_result_df = self.exp.pull()
+        self._collect_test_results_from_pycaret()
         if self.task_type == "classification":
             self.test_result_df.rename(
                 columns={"AUC": "ROC-AUC"}, inplace=True
@@ -819,6 +822,73 @@ class BaseModelTrainer:
                 columns={"PR-AUC-Weighted": "PR-AUC"}, inplace=True
             )
             self._replace_test_pr_auc()
+
+    def _collect_test_results_from_pycaret(self):
+        """
+        Collect PyCaret's held-out metric table, falling back to local metric
+        computation when PyCaret's multiclass predict_model path fails while
+        constructing its prediction DataFrame.
+        """
+        prob_thresh = getattr(self, "probability_threshold", None)
+        is_multiclass = (
+            self.task_type == "classification"
+            and getattr(self.exp, "is_multiclass", False)
+        )
+        predict_kwargs = {}
+        if (
+            self.task_type == "classification"
+            and prob_thresh is not None
+            and not is_multiclass
+        ):
+            predict_kwargs["probability_threshold"] = prob_thresh
+
+        try:
+            _ = self.exp.predict_model(self.best_model, **predict_kwargs)
+            self.test_result_df = self.exp.pull()
+            return
+        except ValueError as exc:
+            if not (
+                is_multiclass
+                and "Shape of passed values" in str(exc)
+                and "indices imply" in str(exc)
+            ):
+                raise
+            LOG.warning(
+                "PyCaret predict_model failed on multiclass prediction shape; "
+                "using GLEAM-computed held-out test metrics instead: %s",
+                exc,
+            )
+
+        self.test_result_df = self._build_fallback_test_result_df()
+
+    def _build_fallback_test_result_df(self):
+        """
+        Build a one-row held-out test metric table without PyCaret predict_model.
+        This is used only when PyCaret cannot format multiclass predictions.
+        """
+        preds = self._get_test_predictions_for_report()
+        if preds is None:
+            LOG.warning(
+                "Could not compute fallback held-out test metrics; no test "
+                "prediction bundle was available."
+            )
+            return pd.DataFrame()
+
+        metric_columns = [
+            ("Accuracy", "Accuracy"),
+            ("ROC-AUC", "ROC-AUC"),
+            ("Precision", "Prec."),
+            ("Recall", "Recall"),
+            ("F1-Score", "F1"),
+            ("PR-AUC", "PR-AUC"),
+            ("Kappa", "Kappa"),
+            ("MCC", "MCC"),
+        ]
+        row = {}
+        for metric_name, column_name in metric_columns:
+            value = self._compute_metric_value(metric_name, preds, "Test")
+            row[column_name] = value if value is not None else np.nan
+        return pd.DataFrame([row])
 
     def _configure_decision_threshold(self):
         """
@@ -2006,6 +2076,8 @@ class BaseModelTrainer:
                     )
             if metric_name == "PR-AUC":
                 return self._compute_pr_auc_from_predictions(preds)
+            if metric_name == "Kappa":
+                return cohen_kappa_score(y_true, y_pred)
             if metric_name == "Specificity":
                 labels = pd.unique(pd.concat([y_true, y_pred], ignore_index=True))
                 if len(labels) != 2:

--- a/tools/tabularlearner/feature_importance.py
+++ b/tools/tabularlearner/feature_importance.py
@@ -498,13 +498,8 @@ class FeatureImportanceAnalyzer:
 
             # 6) AdaBoost
             if "adaboostclassifier" in lname:
-                return (
-                    shap.TreeExplainer(
-                        model, bg, feature_perturbation="tree_path_dependent", n_jobs=-1
-                    ),
-                    "tree_path_dependent",
-                    True,
-                )
+                fn = model.predict_proba if hasattr(model, "predict_proba") else predict_fn
+                return _permutation(fn), "permutation-adaboost", False
 
             # 7) Extra Trees
             if "extratreesclassifier" in lname:
@@ -626,7 +621,6 @@ class FeatureImportanceAnalyzer:
             "decisiontreeregressor",
             "randomforestregressor",
             "extratreesregressor",
-            "adaboostregressor",
             "gradientboostingregressor",
         ]
         if any(k in lname for k in tree_class_names):
@@ -637,6 +631,8 @@ class FeatureImportanceAnalyzer:
                 "tree_path_dependent",
                 True,
             )
+        if "adaboostregressor" in lname:
+            return _permutation(predict_fn), "permutation-adaboost", False
 
         # Boosting libraries
         if "lgbmregressor" in lname or "lightgbm" in lname:

--- a/tools/tabularlearner/feature_importance.py
+++ b/tools/tabularlearner/feature_importance.py
@@ -311,6 +311,27 @@ class FeatureImportanceAnalyzer:
                     )
                     self.shap_model_name = None
                     return
+            elif explainer_label == "linear":
+                LOG.warning(
+                    "SHAP computation failed using LinearExplainer (%s). "
+                    "Falling back to model-agnostic permutation explainer.",
+                    error_message,
+                )
+                try:
+                    agnostic_explainer = shap.Explainer(
+                        predict_fn, bg, algorithm="permutation"
+                    )
+                    shap_values = agnostic_explainer(X_data)
+                    self.shap_model_name = (
+                        f"{agnostic_explainer.__class__.__name__} (fallback)"
+                    )
+                except Exception as fallback_exc:
+                    LOG.error(
+                        "Model-agnostic SHAP fallback also failed: %s",
+                        fallback_exc,
+                    )
+                    self.shap_model_name = None
+                    return
             else:
                 LOG.error(f"SHAP computation failed: {e}")
                 self.shap_model_name = None
@@ -461,7 +482,7 @@ class FeatureImportanceAnalyzer:
         if task == "classification":
             # 1) Logistic Regression
             if "logisticregression" in lname:
-                return _permutation(model.predict_proba), "permutation-proba", False
+                return shap.LinearExplainer(model, bg), "linear", False
 
             # 2) Ridge Classifier
             if "ridgeclassifier" in lname:

--- a/tools/tabularlearner/pycaret_classification.py
+++ b/tools/tabularlearner/pycaret_classification.py
@@ -283,29 +283,11 @@ class ClassificationModelTrainer(BaseModelTrainer):
             except Exception as e:
                 LOG.error(f"Error generating explainer plot {key}: {e}")
 
-        if self._explainer_feature_count_exceeds_cap():
-            LOG.info(
-                "Skipping ExplainerDashboard SHAP/permutation importance because "
-                "the transformed test set has %s features; custom SHAP remains capped "
-                "to top %s features.",
-                self.explainer_scope.total_features,
-                self.explainer_scope.feature_cap,
-            )
-            self.explainer_dashboard_importance_skipped = True
-        else:
-            # mean SHAP importances
-            try:
-                self.explainer_plots["shap_mean"] = explainer.plot_importances()
-            except Exception as e:
-                LOG.warning(f"Could not generate shap_mean: {e}")
-
-            # permutation importances
-            try:
-                self.explainer_plots["shap_perm"] = lambda: explainer.plot_importances(
-                    kind="permutation"
-                )
-            except Exception as e:
-                LOG.warning(f"Could not generate shap_perm: {e}")
+        LOG.info(
+            "Skipping ExplainerDashboard SHAP/permutation importance; "
+            "custom model-specific SHAP is generated once in Feature Importance."
+        )
+        self.explainer_dashboard_importance_skipped = True
 
         # PDPs for each feature (appended last)
         valid_feats = []

--- a/tools/tabularlearner/pycaret_macros.xml
+++ b/tools/tabularlearner/pycaret_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TABULAR_LEARNER_VERSION@">0.1.5</token>
+    <token name="@TABULAR_LEARNER_VERSION@">0.1.6</token>
     <token name="@PYCARET_VERSION@">3.3.2</token>
     <token name="@SUFFIX@">2</token>
     <token name="@PYCARET_PREDICT_VERSION@">@PYCARET_VERSION@+@SUFFIX@</token>

--- a/tools/tabularlearner/pycaret_macros.xml
+++ b/tools/tabularlearner/pycaret_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TABULAR_LEARNER_VERSION@">0.1.6</token>
+    <token name="@TABULAR_LEARNER_VERSION@">0.1.5</token>
     <token name="@PYCARET_VERSION@">3.3.2</token>
     <token name="@SUFFIX@">2</token>
     <token name="@PYCARET_PREDICT_VERSION@">@PYCARET_VERSION@+@SUFFIX@</token>

--- a/tools/tabularlearner/pycaret_regression.py
+++ b/tools/tabularlearner/pycaret_regression.py
@@ -80,29 +80,11 @@ class RegressionModelTrainer(BaseModelTrainer):
             LOG.error(f"Error creating explainer: {e}")
             return
 
-        if self._explainer_feature_count_exceeds_cap():
-            LOG.info(
-                "Skipping ExplainerDashboard SHAP/permutation importance because "
-                "the transformed test set has %s features; custom SHAP remains capped "
-                "to top %s features.",
-                self.explainer_scope.total_features,
-                self.explainer_scope.feature_cap,
-            )
-            self.explainer_dashboard_importance_skipped = True
-        else:
-            # --- 1) SHAP mean impact (average absolute SHAP values) ---
-            try:
-                self.explainer_plots["shap_mean"] = explainer.plot_importances()
-            except Exception as e:
-                LOG.error(f"Error generating SHAP mean importance: {e}")
-
-            # --- 2) SHAP permutation importance ---
-            try:
-                self.explainer_plots["shap_perm"] = explainer.plot_importances_permutation(
-                    kind="permutation"
-                )
-            except Exception as e:
-                LOG.error(f"Error generating SHAP permutation importance: {e}")
+        LOG.info(
+            "Skipping ExplainerDashboard SHAP/permutation importance; "
+            "custom model-specific SHAP is generated once in Feature Importance."
+        )
+        self.explainer_dashboard_importance_skipped = True
 
         # Pre-filter features so we never call PDP or residual-vs-feature on missing cols
         valid_feats = []

--- a/tools/tabularlearner/pycaret_train.py
+++ b/tools/tabularlearner/pycaret_train.py
@@ -129,6 +129,18 @@ def main():
         help="Probability threshold for classification decision,",
     )
     parser.add_argument(
+        "--threshold_mode",
+        choices=["auto", "manual"],
+        default="auto",
+        help="Whether to optimize the binary classification threshold or use a manual value.",
+    )
+    parser.add_argument(
+        "--threshold_metric",
+        type=str,
+        default="F1",
+        help="Metric used for automatic binary threshold optimization.",
+    )
+    parser.add_argument(
         "--best_model_metric",
         type=str,
         default=None,
@@ -180,6 +192,8 @@ def main():
         "tune_model": args.tune_model,
         "n_jobs": n_jobs,
         "probability_threshold": args.probability_threshold,
+        "threshold_mode": args.threshold_mode,
+        "threshold_metric": args.threshold_metric,
         "best_model_metric": args.best_model_metric,
         "sample_id_column": args.sample_id_column,
     }
@@ -207,6 +221,9 @@ def main():
     elif args.model_type == "regression":
         # regression doesn't support fix_imbalance
         model_kwargs.pop("fix_imbalance", None)
+        model_kwargs.pop("probability_threshold", None)
+        model_kwargs.pop("threshold_mode", None)
+        model_kwargs.pop("threshold_metric", None)
         trainer = RegressionModelTrainer(
             args.input_file,
             args.target_col,

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -53,8 +53,14 @@
         #if $customize_defaults_section.fix_imbalance
             --fix_imbalance
         #end if
-        #if $customize_defaults_section.probability_threshold
-            --probability_threshold '$customize_defaults_section.probability_threshold'
+        #if $model_hyperparameter_configuration.model_selection.model_type == "classification"
+            #if $customize_defaults_section.binary_threshold_policy.mode == "auto"
+                --threshold_mode auto
+                --threshold_metric '$customize_defaults_section.binary_threshold_policy.threshold_metric'
+            #else
+                --threshold_mode manual
+                --probability_threshold '$customize_defaults_section.binary_threshold_policy.probability_threshold'
+            #end if
         #end if
         #if $data_configuration.test_data_choice.has_test_file == "yes"
             --test_file '$data_configuration.test_data_choice.test_file'
@@ -195,7 +201,28 @@
             <param name="remove_multicollinearity" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Remove Multicollinearity" help="Whether to remove multicollinear features before training." />
             <param name="polynomial_features" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Polynomial Features" help="Whether to create polynomial features before training." />
             <param name="fix_imbalance" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Fix Imbalance" help="ONLY for classfication! Whether to use SMOTE or similar methods to fix imbalance in the input dataset." />
-            <param name="probability_threshold" type="float" min="0.0" max="1.0" value="0.5" label="Classification Probability Threshold" help="Only applies to classification. Probability above which a prediction is considered positive. Default is 0.5." />
+            <conditional name="binary_threshold_policy">
+                <param name="mode" type="select" label="Binary classification threshold">
+                    <option value="auto" selected="true">Auto: optimize threshold by metric</option>
+                    <option value="manual">Manual: set threshold value</option>
+                </param>
+                <when value="auto">
+                    <param name="threshold_metric" type="select" label="Threshold optimization metric"
+                           help="Used only for binary classification. PyCaret optimizes the decision threshold for the selected metric.">
+                        <option value="F1" selected="true">F1</option>
+                        <option value="Accuracy">Accuracy</option>
+                        <option value="Precision">Precision</option>
+                        <option value="Recall">Recall</option>
+                        <option value="Kappa">Cohen's Kappa</option>
+                        <option value="MCC">Matthews Correlation Coefficient</option>
+                    </param>
+                </when>
+                <when value="manual">
+                    <param name="probability_threshold" type="float" min="0.0" max="1.0" value="0.5"
+                           label="Manual threshold value"
+                           help="Only applies to binary classification. Probability above which a prediction is considered positive." />
+                </when>
+            </conditional>
         </section>
     </inputs>
     <outputs>
@@ -217,7 +244,8 @@
             <param name="cross_validation|cross_validation_folds" value="5"/>
             <param name="remove_outliers" value="true"/>
             <param name="remove_multicollinearity" value="true"/>
-            <param name="probability_threshold" value="0.4" />
+            <param name="binary_threshold_policy|mode" value="manual" />
+            <param name="binary_threshold_policy|probability_threshold" value="0.4" />
             <output name="model" file="expected_model_classification_customized.h5" compare="sim_size"/>
             <output name="comparison_result">
                 <assert_contents>
@@ -232,6 +260,8 @@
                     <has_text text="Train and Test metrics are computed by scoring the selected best model on the training/CV pool and held-out test set" />
                     <has_text text="These values can slightly differ from Best Model Performance table." />
                     <has_text text="F1" />
+                    <has_text text="Decision threshold (Test)" />
+                    <has_text text="Threshold source" />
                 </assert_contents>
             </output>
             <output name="best_model_csv" value="expected_best_model_classification_customized.csv" />
@@ -247,7 +277,8 @@
             <param name="cross_validation|enable_cross_validation" value="false"/>
             <param name="remove_outliers" value="true"/>
             <param name="remove_multicollinearity" value="true"/>
-            <param name="probability_threshold" value="0.6" />
+            <param name="binary_threshold_policy|mode" value="manual" />
+            <param name="binary_threshold_policy|probability_threshold" value="0.6" />
             <output name="model" file="expected_model_classification_customized_cross_off.h5" compare="sim_size"/>
             <output name="comparison_result">
                 <assert_contents>
@@ -268,6 +299,8 @@
             <param name="random_seed" value="42"/>
             <param name="cross_validation|enable_cross_validation" value="false"/>
             <param name="tune_model" value="true"/>
+            <param name="binary_threshold_policy|mode" value="manual" />
+            <param name="binary_threshold_policy|probability_threshold" value="0.5" />
             <output name="model" file="expected_model_classification.h5" compare="sim_size"/>
             <output name="comparison_result"> 
                 <assert_contents>
@@ -293,6 +326,8 @@
             <param name="model_selection|classification_models" value="lightgbm"/>
             <param name="random_seed" value="42"/>
             <param name="cross_validation|enable_cross_validation" value="false"/>
+            <param name="binary_threshold_policy|mode" value="manual" />
+            <param name="binary_threshold_policy|probability_threshold" value="0.5" />
             <output name="model" file="expected_model_classification.h5" compare="sim_size"/>
             <output name="comparison_result"> 
                 <assert_contents>

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -268,8 +268,9 @@
                     <has_text text="Cross-Validation Fold Allocation" />
                     <has_text text="Validation Samples" />
                     <has_text text="Internal Cross-Validation Summary Across Candidate Models" />
-                    <has_text text="The Training / CV Pool column shows the total samples used for training and validation" />
-                    <has_text text="Train and Test metrics are computed by scoring the selected best model on the training/CV pool and held-out test set" />
+                    <has_text text="Dataset Overview" />
+                    <has_text text="Best Model Performance" />
+                    <has_text text="Training" />
                     <has_text text="These values can slightly differ from Best Model Performance table." />
                     <has_text text="F1" />
                     <has_text text="Decision threshold (Test)" />

--- a/tools/tabularlearner/utils.py
+++ b/tools/tabularlearner/utils.py
@@ -74,6 +74,14 @@ def get_html_template() -> str:
           .table-perf-summary th:nth-child(n+2) {
               text-align: center;
           }
+          .table-model-comparison td:nth-child(n+2),
+          .table-model-comparison th:nth-child(n+2) {
+              text-align: center;
+          }
+          .table-model-comparison td:first-child,
+          .table-model-comparison th:first-child {
+              text-align: left;
+          }
           .table-cv-fold-allocation td,
           .table-cv-fold-allocation th {
               text-align: center;


### PR DESCRIPTION
## Summary
- Adds Tabular Learner controls for binary decision threshold policy: automatic optimization or manual threshold.
- Uses PyCaret `optimize_threshold()` for automatic threshold selection, defaulting to F1.
- Adds selectable threshold metrics for automatic mode.
- Reports the selected threshold, threshold source, and optimization metric in the Experiment and Data Parameters table.
- Guards threshold handling so multiclass and regression tasks skip binary threshold logic safely.