### PR TITLE
[codex] Refresh reviewer example workflow links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@
             <div class="tool-actions">
               <a
                 class="button primary workflow-button"
-                href="https://usegalaxy.org/workflow_landings/fc7da6e4-aa4f-47a0-9feb-eda4ee2a0e11?public=true"
+                href="https://usegalaxy.org/workflow_landings/26f12085-2187-4d70-bbaa-4aecb64b534b?public=true"
               >
                 Launch the tool with example data
               </a>
@@ -119,12 +119,12 @@
             <div class="tool-actions">
               <a
                 class="button primary workflow-button"
-                href="https://usegalaxy.org/workflow_landings/872a6146-1f63-483c-9a4a-358968ed2142?public=true"
+                href="https://usegalaxy.org/workflow_landings/a4c388d2-6315-4153-a315-2c47eb9d0188?public=true"
               >
                 Launch the tool with example data
               </a>
               <div class="link-row">
-                <a href="https://usegalaxy.org/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fgoeckslab%2Fimage_learner%2Fimage_learner%2F0.1.5">Open on usegalaxy.org</a>
+                <a href="https://usegalaxy.org/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fgoeckslab%2Fimage_learner%2Fimage_learner%2F0.1.6">Open on usegalaxy.org</a>
                 <a href="https://github.com/goeckslab/gleam/tree/main/tools/imagelearner">Docs</a>
               </div>
             </div>
@@ -139,7 +139,7 @@
             <div class="tool-actions">
               <a
                 class="button primary workflow-button"
-                href="https://usegalaxy.org/workflow_landings/01a1f6ec-ac41-4735-9e24-62bed8aef842?public=true"
+                href="https://usegalaxy.org/workflow_landings/a3c38b70-f17f-4902-93ff-595d9a1ac53e?public=true"
               >
                 Launch the tool with example data
               </a>


### PR DESCRIPTION
## Summary

- Replace the GLEAM page's prepared example-data workflow landing URLs with refreshed public landing requests.
- Preserve the reviewer-facing `Launch the tool with example data` buttons.
- Update the Image Learner direct tool link from `0.1.5` to `0.1.6`.

## Why

The previous workflow landing URLs opened Galaxy pages that showed a stale-tool warning because the saved workflows referenced older tool state. The new landing URLs point at upgraded stored workflow copies while preserving the prepared input mappings reviewers need for one-click example runs.

## Validation

- Checked all three new usegalaxy.org workflow landing pages for stale-workflow warning text.
- Confirmed `docs/index.html` still contains `Launch the tool with example data` for all three tool cards.
