### PR TITLE
explicit hits at k

### DIFF
--- a/tools/imagelearner/constants.py
+++ b/tools/imagelearner/constants.py
@@ -172,6 +172,7 @@ MODEL_ENCODER_TEMPLATES: Dict[str, Any] = {
     "mobilenet_v3_large": {"type": "mobilenetv3", "model_variant": "large"},
     "mobilenet_v3_small": {"type": "mobilenetv3", "model_variant": "small"},
 }
+DEFAULT_HITS_AT_K = 3
 METRIC_DISPLAY_NAMES = {
     "accuracy": "Accuracy",
     "balanced_accuracy": "Balanced Accuracy",
@@ -180,7 +181,7 @@ METRIC_DISPLAY_NAMES = {
     "roc_auc": "ROC-AUC",
     "roc_auc_macro": "Macro ROC-AUC",
     "roc_auc_micro": "Micro ROC-AUC",
-    "hits_at_k": "Hits at K",
+    "hits_at_k": f"Hits@{DEFAULT_HITS_AT_K}",
     "precision": "Precision",
     "recall": "Recall",
     "specificity": "Specificity",

--- a/tools/imagelearner/html_structure.py
+++ b/tools/imagelearner/html_structure.py
@@ -2,7 +2,7 @@ import base64
 import json
 from typing import Any, Dict, List, Optional
 
-from constants import METRIC_DISPLAY_NAMES
+from constants import DEFAULT_HITS_AT_K, METRIC_DISPLAY_NAMES
 from utils import detect_output_type, extract_metrics_from_json
 
 
@@ -13,6 +13,13 @@ def generate_table_row(cells, styles):
         + "".join(f"<td style='{styles}'>{cell}</td>" for cell in cells)
         + "</tr>"
     )
+
+
+def format_metric_display_name(metric_key: str, top_k: int = DEFAULT_HITS_AT_K) -> str:
+    """Return a user-facing metric label with resolved parameters."""
+    if metric_key == "hits_at_k":
+        return f"Hits@{int(top_k)}"
+    return METRIC_DISPLAY_NAMES.get(metric_key, metric_key.replace("_", " ").title())
 
 
 def format_config_table_html(
@@ -29,6 +36,7 @@ def format_config_table_html(
         "target_column",
         "task_type",
         "validation_metric",
+        "top_k",
         "loss_function",
         "threshold",
         "threshold_source",
@@ -56,7 +64,17 @@ def format_config_table_html(
     for key in display_keys:
         val_str = "N/A"
         val = config.get(key, None)
-        if key == "threshold":
+        display_label = label_map.get(key, key.replace("_", " ").title())
+        if key == "top_k":
+            if output_type != "category" or val is None:
+                continue
+            top_k = int(val)
+            display_label = f"Hits@{top_k} Top Classes"
+            val_str = (
+                f"{top_k} "
+                f"(the correct class must appear in the top {top_k} predictions)"
+            )
+        elif key == "threshold":
             if output_type != "binary":
                 continue
             val = val if val is not None else 0.5
@@ -136,7 +154,9 @@ def format_config_table_html(
                         )
             elif key == "validation_metric":
                 if val is not None:
-                    val_str = METRIC_DISPLAY_NAMES.get(str(val), str(val))
+                    val_str = format_metric_display_name(
+                        str(val), int(config.get("top_k") or DEFAULT_HITS_AT_K)
+                    )
                 else:
                     val_str = "N/A"
             elif key == "epochs":
@@ -177,7 +197,7 @@ def format_config_table_html(
             f"<tr>"
             f"<td style='padding: 6px 12px; border: 1px solid #ccc; text-align: left; "
             f"white-space: normal; word-break: break-word; overflow-wrap: anywhere;'>"
-            f"{label_map.get(key, key.replace('_', ' ').title())}</td>"
+            f"{display_label}</td>"
             f"<td style='padding: 6px 12px; border: 1px solid #ccc; text-align: center; "
             f"white-space: normal; word-break: break-word; overflow-wrap: anywhere;'>"
             f"{val_str}</td>"
@@ -699,8 +719,10 @@ def get_metrics_help_modal() -> str:
         '      <p><strong>False Positives / Negatives (FP / FN):</strong> Incorrect predictions '
         '— false alarms and missed detections.</p>'
         '      <h3>8) Classification: Ranking Metrics</h3>'
-        '      <p><strong>Hits at K:</strong> Measures whether the true label is among the '
-        'top-K predictions. Common in recommendation systems and retrieval tasks.</p>'
+        f'      <p><strong>Hits@{DEFAULT_HITS_AT_K}:</strong> Measures whether the true label '
+        f'is among the model\'s top {DEFAULT_HITS_AT_K} predictions. For example, '
+        f'80% means the correct class appeared somewhere in the top {DEFAULT_HITS_AT_K} '
+        'guesses for 80% of samples.</p>'
         '      <h3>9) Other Metrics (Classification)</h3>'
         '      <p><strong>Cohen\'s Kappa:</strong> Measures agreement between predicted and '
         'actual labels, adjusted for chance. Useful for multiclass classification with '
@@ -724,7 +746,8 @@ def get_metrics_help_modal() -> str:
         'or <strong>Macro ROC-AUC</strong>.</li>'
         '        <li><strong>Class Frequency Matters:</strong> Use <strong>Weighted Precision/Recall/F1</strong> '
         'to account for class imbalance.</li>'
-        '        <li><strong>Recommendation/Ranking:</strong> Use <strong>Hits at K</strong> for retrieval tasks.</li>'
+        f'        <li><strong>Recommendation/Ranking:</strong> Use <strong>Hits@{DEFAULT_HITS_AT_K}</strong> '
+        'when it matters whether the correct class is near the top, not only ranked first.</li>'
         '        <li><strong>Detailed Analysis:</strong> Use <strong>Confusion Matrix stats</strong> '
         'for class-wise performance in classification.</li>'
         '      </ul>'
@@ -853,7 +876,12 @@ def format_image_match_notice(match_summary: Optional[Dict[str, Any]]) -> str:
 # -----------------------------------------
 
 
-def format_stats_table_html(train_stats: dict, test_stats: dict, output_type: str) -> str:
+def format_stats_table_html(
+    train_stats: dict,
+    test_stats: dict,
+    output_type: str,
+    top_k: int = DEFAULT_HITS_AT_K,
+) -> str:
     """Formats a combined HTML table for training, validation, and test metrics."""
     all_metrics = extract_metrics_from_json(train_stats, test_stats, output_type)
     rows = []
@@ -862,15 +890,19 @@ def format_stats_table_html(train_stats: dict, test_stats: dict, output_type: st
             metric_key in all_metrics["validation"]
             and metric_key in all_metrics["test"]
         ):
-            display_name = METRIC_DISPLAY_NAMES.get(
-                metric_key,
-                metric_key.replace("_", " ").title(),
-            )
+            display_name = format_metric_display_name(metric_key, top_k)
             t = all_metrics["training"].get(metric_key)
             v = all_metrics["validation"].get(metric_key)
             te = all_metrics["test"].get(metric_key)
             if all(x is not None for x in [t, v, te]):
-                rows.append([display_name, f"{t:.4f}", f"{v:.4f}", f"{te:.4f}"])
+                rows.append(
+                    [
+                        display_name,
+                        f"{t:.4f}",
+                        f"{v:.4f}",
+                        f"{te:.4f}",
+                    ]
+                )
 
     if not rows:
         return "<table><tr><td>No metric values found.</td></tr></table>"
@@ -899,20 +931,27 @@ def format_stats_table_html(train_stats: dict, test_stats: dict, output_type: st
 # -------------------------------------------
 
 
-def format_train_val_stats_table_html(train_stats: dict, test_stats: dict) -> str:
+def format_train_val_stats_table_html(
+    train_stats: dict,
+    test_stats: dict,
+    top_k: int = DEFAULT_HITS_AT_K,
+) -> str:
     """Format train/validation metrics into an HTML table."""
     all_metrics = extract_metrics_from_json(train_stats, test_stats, detect_output_type(test_stats))
     rows = []
     for metric_key in sorted(all_metrics["training"].keys()):
         if metric_key in all_metrics["validation"]:
-            display_name = METRIC_DISPLAY_NAMES.get(
-                metric_key,
-                metric_key.replace("_", " ").title(),
-            )
+            display_name = format_metric_display_name(metric_key, top_k)
             t = all_metrics["training"].get(metric_key)
             v = all_metrics["validation"].get(metric_key)
             if t is not None and v is not None:
-                rows.append([display_name, f"{t:.4f}", f"{v:.4f}"])
+                rows.append(
+                    [
+                        display_name,
+                        f"{t:.4f}",
+                        f"{v:.4f}",
+                    ]
+                )
 
     if not rows:
         return "<table><tr><td>No metric values found for Train/Validation.</td></tr></table>"
@@ -941,12 +980,14 @@ def format_train_val_stats_table_html(train_stats: dict, test_stats: dict) -> st
 
 
 def format_test_merged_stats_table_html(
-    test_metrics: Dict[str, Any], output_type: str
+    test_metrics: Dict[str, Any],
+    output_type: str,
+    top_k: int = DEFAULT_HITS_AT_K,
 ) -> str:
     """Format test metrics into an HTML table."""
     rows = []
     for key in sorted(test_metrics.keys()):
-        display_name = METRIC_DISPLAY_NAMES.get(key, key.replace("_", " ").title())
+        display_name = format_metric_display_name(key, top_k)
         value = test_metrics[key]
         if value is not None:
             rows.append([display_name, f"{value:.4f}"])

--- a/tools/imagelearner/ludwig_backend.py
+++ b/tools/imagelearner/ludwig_backend.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pandas.api.types as ptypes
 import yaml
 from constants import (
+    DEFAULT_HITS_AT_K,
     IMAGE_PATH_COLUMN_NAME,
     LABEL_COLUMN_NAME,
     MODEL_ENCODER_TEMPLATES,
@@ -551,10 +552,12 @@ class LudwigDirectBackend:
                 ):
                     output_feat["threshold"] = float(config_params["threshold"])
             else:
+                category_top_k = min(DEFAULT_HITS_AT_K, max(1, int(num_unique_labels)))
                 output_feat = {
                     "name": LABEL_COLUMN_NAME,
                     "type": "category",
                     "loss": {"type": "softmax_cross_entropy"},
+                    "top_k": category_top_k,
                 }
             val_metric = _resolve_validation_metric(
                 "binary" if num_unique_labels == 2 else "category",
@@ -1386,7 +1389,7 @@ class LudwigDirectBackend:
             "output_feature_name": output_feature,
             "ground_truth_split": 2,
             "top_n_classes": [20],
-            "top_k": 3,
+            "top_k": DEFAULT_HITS_AT_K,
             "metrics": ["f1", "precision", "recall", "accuracy"],
             "positive_label": 0,
             "ground_truth_metadata": gt_metadata,
@@ -1501,6 +1504,7 @@ class LudwigDirectBackend:
                     "target_column": output_cfg.get("column"),
                     "task_type": output_cfg.get("type"),
                     "validation_metric": trainer_cfg.get("validation_metric"),
+                    "top_k": output_cfg.get("top_k"),
                     "loss_function": loss_cfg.get("type"),
                     "threshold": output_cfg.get("threshold"),
                     "total_epochs": trainer_cfg.get("epochs"),
@@ -1757,6 +1761,7 @@ class LudwigDirectBackend:
         train_val_metrics_html = ""
         test_metrics_html = ""
         output_type = None
+        hits_top_k = int(config_for_summary.get("top_k") or DEFAULT_HITS_AT_K)
         train_stats_path = exp_dir / "training_statistics.json"
         test_stats_path = exp_dir / TEST_STATISTICS_FILE_NAME
         try:
@@ -1766,14 +1771,18 @@ class LudwigDirectBackend:
                 with open(test_stats_path) as f:
                     test_stats = json.load(f)
                 output_type = detect_output_type(test_stats)
-                metrics_html = format_stats_table_html(train_stats, test_stats, output_type)
+                metrics_html = format_stats_table_html(
+                    train_stats, test_stats, output_type, top_k=hits_top_k
+                )
                 train_val_metrics_html = format_train_val_stats_table_html(
-                    train_stats, test_stats
+                    train_stats, test_stats, top_k=hits_top_k
                 )
                 test_metrics_html = format_test_merged_stats_table_html(
                     extract_metrics_from_json(train_stats, test_stats, output_type)[
                         "test"
-                    ], output_type
+                    ],
+                    output_type,
+                    top_k=hits_top_k,
                 )
         except Exception as e:
             logger.warning(
@@ -1861,7 +1870,7 @@ class LudwigDirectBackend:
                 )
                 if threshold_metrics:
                     test_metrics_html = format_test_merged_stats_table_html(
-                        threshold_metrics, output_type
+                        threshold_metrics, output_type, top_k=hits_top_k
                     )
             except Exception as exc:
                 logger.warning(
@@ -2015,7 +2024,9 @@ class LudwigDirectBackend:
                     tv_plots = build_regression_train_val_plots(str(train_stats_path))
                     tab2_content = append_plot_blocks(tab2_content, tv_plots)
                 else:
-                    tv_plots = build_train_validation_plots(str(train_stats_path))
+                    tv_plots = build_train_validation_plots(
+                        str(train_stats_path), top_k=hits_top_k
+                    )
                     # Add threshold plot first, then other train/val plots
                     if threshold_plot:
                         tab2_content = append_plot_blocks(tab2_content, [threshold_plot])

--- a/tools/imagelearner/plotly_plots.py
+++ b/tools/imagelearner/plotly_plots.py
@@ -7,7 +7,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import plotly.io as pio
 from calibration_plot import expected_calibration_error
-from constants import LABEL_COLUMN_NAME, SPLIT_COLUMN_NAME
+from constants import DEFAULT_HITS_AT_K, LABEL_COLUMN_NAME, SPLIT_COLUMN_NAME
 from sklearn.calibration import calibration_curve
 from sklearn.metrics import (
     accuracy_score,
@@ -435,7 +435,9 @@ def build_classification_plots(
     return plots
 
 
-def build_train_validation_plots(train_stats_path: str) -> List[Dict[str, str]]:
+def build_train_validation_plots(
+    train_stats_path: str, top_k: int = DEFAULT_HITS_AT_K
+) -> List[Dict[str, str]]:
     """Generate Train/Validation learning curve plots from training_statistics.json."""
     if not train_stats_path or not Path(train_stats_path).exists():
         return []
@@ -465,6 +467,11 @@ def build_train_validation_plots(train_stats_path: str) -> List[Dict[str, str]]:
     metric_specs = [
         ("loss", "Loss across epochs", "Loss"),
         ("accuracy", "Accuracy across epochs", "Accuracy"),
+        (
+            "hits_at_k",
+            f"Hits@{int(top_k)} across epochs (correct class in top {int(top_k)})",
+            f"Hits@{int(top_k)}",
+        ),
         ("roc_auc", "ROC-AUC across epochs", "ROC-AUC"),
         ("precision", "Precision across epochs", "Precision"),
         ("recall", "Recall/Sensitivity across epochs", "Recall"),
@@ -542,6 +549,7 @@ def build_train_validation_plots(train_stats_path: str) -> List[Dict[str, str]]:
         for metric_key, label in [
             ("accuracy", "Accuracy"),
             ("balanced_accuracy", "Balanced Accuracy"),
+            ("hits_at_k", f"Hits@{int(top_k)}"),
             ("precision", "Precision"),
             ("recall", "Recall"),
             ("specificity", "Specificity"),

--- a/tools/imagelearner/test_image_workflow.py
+++ b/tools/imagelearner/test_image_workflow.py
@@ -112,3 +112,44 @@ def test_format_image_match_notice_omits_clean_matches():
         )
         == ""
     )
+
+
+def test_metric_summary_formats_hits_at_3_without_changing_metric_values():
+    html_structure = importlib.import_module("html_structure")
+    train_stats = {
+        "training": {
+            "label": {
+                "accuracy": [0.2],
+                "hits_at_k": [0.8],
+                "loss": [1.25],
+                "roc_auc": [0.7],
+            }
+        },
+        "validation": {
+            "label": {
+                "accuracy": [0.3],
+                "hits_at_k": [0.6],
+                "loss": [1.5],
+                "roc_auc": [0.75],
+            }
+        },
+    }
+    test_stats = {
+        "label": {
+            "accuracy": 0.4,
+            "hits_at_k": 0.9,
+            "loss": 1.1,
+            "roc_auc": 0.8,
+            "per_class_stats": {"a": {}, "b": {}, "c": {}},
+        }
+    }
+
+    html = html_structure.format_stats_table_html(
+        train_stats, test_stats, "category", top_k=3
+    )
+
+    assert "Hits@3" in html
+    assert "0.9000" in html
+    assert "90.0%" not in html
+    assert "Loss and regression errors remain raw scores" not in html
+    assert "1.1000" in html

--- a/tools/imagelearner/test_ludwig_backend_threshold.py
+++ b/tools/imagelearner/test_ludwig_backend_threshold.py
@@ -4,6 +4,7 @@ import types
 from pathlib import Path
 
 import pandas as pd
+import yaml
 
 
 TOOL_DIR = Path(__file__).resolve().parent
@@ -98,3 +99,26 @@ def test_generate_validation_predictions_writes_split_specific_file(tmp_path):
     assert df[split_col].tolist() == [1, 1]
     assert df[label_col].tolist() == [1, 0]
     assert df["label_probabilities_1"].tolist() == [0.8, 0.3]
+
+
+def test_prepare_config_records_category_top_k():
+    (
+        _image_path_col,
+        _label_col,
+        _split_col,
+        LudwigDirectBackend,
+    ) = _load_backend_test_objects()
+
+    yaml_str = LudwigDirectBackend().prepare_config(
+        {
+            "model_name": "resnet18",
+            "use_pretrained": False,
+            "epochs": 1,
+            "label_metadata": {"num_unique": 5},
+        },
+        {"type": "random", "probabilities": [0.7, 0.1, 0.2]},
+    )
+    config = yaml.safe_load(yaml_str)
+
+    assert config["output_features"][0]["type"] == "category"
+    assert config["output_features"][0]["top_k"] == 3

--- a/tools/imagelearner/test_plotly_plots.py
+++ b/tools/imagelearner/test_plotly_plots.py
@@ -4,6 +4,7 @@ from plotly_plots import (
     _resolve_display_labels,
     build_binary_threshold_classification_plots_from_predictions,
     build_prediction_diagnostics,
+    build_train_validation_plots,
     load_binary_threshold_data,
     optimize_binary_threshold_values,
     resolve_binary_threshold_for_report,
@@ -16,6 +17,23 @@ def test_resolve_display_labels_decodes_ludwig_indices_before_friendly_lookup():
 
 def test_resolve_display_labels_preserves_original_numeric_labels():
     assert _resolve_display_labels(["1", "2"], ["1", "2"]) == ["1", "2"]
+
+
+def test_train_validation_plots_include_hits_at_3_when_available(tmp_path):
+    stats_path = tmp_path / "training_statistics.json"
+    stats_path.write_text(
+        """
+{
+  "training": {"label": {"hits_at_k": [0.2, 0.4], "loss": [1.2, 1.0]}},
+  "validation": {"label": {"hits_at_k": [0.1, 0.3], "loss": [1.4, 1.1]}}
+}
+"""
+    )
+
+    plots = build_train_validation_plots(str(stats_path), top_k=3)
+    titles = [plot["title"] for plot in plots]
+
+    assert "Hits@3 across epochs (correct class in top 3)" in titles
 
 
 def test_optimize_binary_threshold_uses_requested_metric():


### PR DESCRIPTION
## Summary

This PR makes the Image Learner `Hits@K` metric explicit in the generated report.

Previously, the report displayed the metric generically as `Hits at K`, without showing the actual configured value of `K`. The report now resolves that value and displays labels such as `Hits@3`, making the metric easier to interpret.

## Changes

- Adds a shared default `Hits@K` value of `3`.
- Explicitly configures Ludwig category outputs with `top_k: 3`.
- Displays `hits_at_k` as `Hits@3` in report metric tables.
- Adds `Hits@3` to the training configuration summary.
- Adds a `Hits@3` train/validation plot when the metric is available.
- Updates report help text to explain that `Hits@3` means the correct class appeared in the model’s top 3 predictions.
