### PR TITLE
Batch size

### DIFF
--- a/tools/imagelearner/html_structure.py
+++ b/tools/imagelearner/html_structure.py
@@ -108,25 +108,10 @@ def format_config_table_html(
                         val_str = (
                             "Auto-selected batch size by Ludwig:<br>"
                             f"<span style='font-size: 0.85em;'>"
-                            f"{resolved_val}</span><br>"
-                            "<span style='font-size: 0.85em;'>"
-                            "Based on model architecture and training setup "
-                            "(e.g., fine-tuning).<br>"
-                            "See <a href='https://ludwig.ai/latest/configuration/trainer/"
-                            "#trainer-parameters' target='_blank'>"
-                            "Ludwig Trainer Parameters</a> for details."
-                            "</span>"
+                            f"{resolved_val}</span>"
                         )
                     else:
-                        val_str = (
-                            "Auto-selected by Ludwig<br>"
-                            "<span style='font-size: 0.85em;'>"
-                            "Automatically tuned based on architecture and dataset.<br>"
-                            "See <a href='https://ludwig.ai/latest/configuration/trainer/"
-                            "#trainer-parameters' target='_blank'>"
-                            "Ludwig Trainer Parameters</a> for details."
-                            "</span>"
-                        )
+                        val_str = "Auto-selected by Ludwig"
             elif key == "learning_rate":
                 if val is not None and val != "auto":
                     val_str = f"{val:.6f}"

--- a/tools/imagelearner/html_structure.py
+++ b/tools/imagelearner/html_structure.py
@@ -121,11 +121,7 @@ def format_config_table_html(
                         val_str = (
                             "Auto-selected learning rate by Ludwig:<br>"
                             f"<span style='font-size: 0.85em;'>"
-                            f"{resolved_val if resolved_val else 'auto'}</span><br>"
-                            "<span style='font-size: 0.85em;'>"
-                            "Based on model architecture and training setup "
-                            "(e.g., fine-tuning).<br>"
-                            "</span>"
+                            f"{resolved_val if resolved_val else 'auto'}</span>"
                         )
                     else:
                         val_str = (

--- a/tools/imagelearner/html_structure.py
+++ b/tools/imagelearner/html_structure.py
@@ -99,34 +99,34 @@ def format_config_table_html(
                 if isinstance(val, (int, float)):
                     val_str = int(val)
                 else:
-                    val = "auto"
-                    val_str = "auto"
-            resolved_val = None
-            if val is None or val == "auto":
-                if training_progress:
-                    resolved_val = training_progress.get("batch_size")
-                    val = (
-                        "Auto-selected batch size by Ludwig:<br>"
-                        f"<span style='font-size: 0.85em;'>"
-                        f"{resolved_val if resolved_val else val}</span><br>"
-                        "<span style='font-size: 0.85em;'>"
-                        "Based on model architecture and training setup "
-                        "(e.g., fine-tuning).<br>"
-                        "See <a href='https://ludwig.ai/latest/configuration/trainer/"
-                        "#trainer-parameters' target='_blank'>"
-                        "Ludwig Trainer Parameters</a> for details."
-                        "</span>"
+                    resolved_val = (
+                        training_progress.get("batch_size")
+                        if training_progress
+                        else None
                     )
-                else:
-                    val = (
-                        "Auto-selected by Ludwig<br>"
-                        "<span style='font-size: 0.85em;'>"
-                        "Automatically tuned based on architecture and dataset.<br>"
-                        "See <a href='https://ludwig.ai/latest/configuration/trainer/"
-                        "#trainer-parameters' target='_blank'>"
-                        "Ludwig Trainer Parameters</a> for details."
-                        "</span>"
-                    )
+                    if resolved_val is not None:
+                        val_str = (
+                            "Auto-selected batch size by Ludwig:<br>"
+                            f"<span style='font-size: 0.85em;'>"
+                            f"{resolved_val}</span><br>"
+                            "<span style='font-size: 0.85em;'>"
+                            "Based on model architecture and training setup "
+                            "(e.g., fine-tuning).<br>"
+                            "See <a href='https://ludwig.ai/latest/configuration/trainer/"
+                            "#trainer-parameters' target='_blank'>"
+                            "Ludwig Trainer Parameters</a> for details."
+                            "</span>"
+                        )
+                    else:
+                        val_str = (
+                            "Auto-selected by Ludwig<br>"
+                            "<span style='font-size: 0.85em;'>"
+                            "Automatically tuned based on architecture and dataset.<br>"
+                            "See <a href='https://ludwig.ai/latest/configuration/trainer/"
+                            "#trainer-parameters' target='_blank'>"
+                            "Ludwig Trainer Parameters</a> for details."
+                            "</span>"
+                        )
             elif key == "learning_rate":
                 if val is not None and val != "auto":
                     val_str = f"{val:.6f}"

--- a/tools/imagelearner/html_structure.py
+++ b/tools/imagelearner/html_structure.py
@@ -106,9 +106,9 @@ def format_config_table_html(
                     )
                     if resolved_val is not None:
                         val_str = (
-                            "Auto-selected batch size by Ludwig:<br>"
-                            f"<span style='font-size: 0.85em;'>"
-                            f"{resolved_val}</span>"
+                            "<span style='font-size: 0.85em;'>"
+                            "Auto-selected batch size by Ludwig:</span><br>"
+                            f"{resolved_val}"
                         )
                     else:
                         val_str = "Auto-selected by Ludwig"
@@ -119,9 +119,9 @@ def format_config_table_html(
                     if training_progress:
                         resolved_val = training_progress.get("learning_rate")
                         val_str = (
-                            "Auto-selected learning rate by Ludwig:<br>"
-                            f"<span style='font-size: 0.85em;'>"
-                            f"{resolved_val if resolved_val else 'auto'}</span>"
+                            "<span style='font-size: 0.85em;'>"
+                            "Auto-selected learning rate by Ludwig:</span><br>"
+                            f"{resolved_val if resolved_val else 'auto'}"
                         )
                     else:
                         val_str = (

--- a/tools/imagelearner/test_image_workflow.py
+++ b/tools/imagelearner/test_image_workflow.py
@@ -165,4 +165,6 @@ def test_config_table_displays_resolved_auto_batch_size():
 
     assert "Auto-selected batch size by Ludwig" in html
     assert "<span style='font-size: 0.85em;'>16</span>" in html
+    assert "Based on model architecture and training setup" not in html
+    assert "Ludwig Trainer Parameters" not in html
     assert ">auto</td>" not in html

--- a/tools/imagelearner/test_image_workflow.py
+++ b/tools/imagelearner/test_image_workflow.py
@@ -153,3 +153,16 @@ def test_metric_summary_formats_hits_at_3_without_changing_metric_values():
     assert "90.0%" not in html
     assert "Loss and regression errors remain raw scores" not in html
     assert "1.1000" in html
+
+
+def test_config_table_displays_resolved_auto_batch_size():
+    html_structure = importlib.import_module("html_structure")
+
+    html = html_structure.format_config_table_html(
+        {"batch_size": "auto"},
+        training_progress={"batch_size": 16},
+    )
+
+    assert "Auto-selected batch size by Ludwig" in html
+    assert "<span style='font-size: 0.85em;'>16</span>" in html
+    assert ">auto</td>" not in html

--- a/tools/imagelearner/test_image_workflow.py
+++ b/tools/imagelearner/test_image_workflow.py
@@ -168,3 +168,16 @@ def test_config_table_displays_resolved_auto_batch_size():
     assert "Based on model architecture and training setup" not in html
     assert "Ludwig Trainer Parameters" not in html
     assert ">auto</td>" not in html
+
+
+def test_config_table_displays_resolved_auto_learning_rate_without_extra_context():
+    html_structure = importlib.import_module("html_structure")
+
+    html = html_structure.format_config_table_html(
+        {"learning_rate": "auto"},
+        training_progress={"learning_rate": 1e-5},
+    )
+
+    assert "Auto-selected learning rate by Ludwig" in html
+    assert "<span style='font-size: 0.85em;'>1e-05</span>" in html
+    assert "Based on model architecture and training setup" not in html

--- a/tools/imagelearner/test_image_workflow.py
+++ b/tools/imagelearner/test_image_workflow.py
@@ -159,7 +159,7 @@ def test_config_table_displays_resolved_auto_batch_size():
     html_structure = importlib.import_module("html_structure")
 
     html = html_structure.format_config_table_html(
-        {"batch_size": "auto"},
+        {"batch_size": "auto", "learning_rate": 0.001},
         training_progress={"batch_size": 16},
     )
 

--- a/tools/imagelearner/test_image_workflow.py
+++ b/tools/imagelearner/test_image_workflow.py
@@ -163,8 +163,12 @@ def test_config_table_displays_resolved_auto_batch_size():
         training_progress={"batch_size": 16},
     )
 
-    assert "Auto-selected batch size by Ludwig" in html
-    assert "<span style='font-size: 0.85em;'>16</span>" in html
+    assert (
+        "<span style='font-size: 0.85em;'>"
+        "Auto-selected batch size by Ludwig:</span>"
+    ) in html
+    assert ">16</td>" in html
+    assert "<span style='font-size: 0.85em;'>16</span>" not in html
     assert "Based on model architecture and training setup" not in html
     assert "Ludwig Trainer Parameters" not in html
     assert ">auto</td>" not in html
@@ -178,6 +182,10 @@ def test_config_table_displays_resolved_auto_learning_rate_without_extra_context
         training_progress={"learning_rate": 1e-5},
     )
 
-    assert "Auto-selected learning rate by Ludwig" in html
-    assert "<span style='font-size: 0.85em;'>1e-05</span>" in html
+    assert (
+        "<span style='font-size: 0.85em;'>"
+        "Auto-selected learning rate by Ludwig:</span>"
+    ) in html
+    assert ">1e-05</td>" in html
+    assert "<span style='font-size: 0.85em;'>1e-05</span>" not in html
     assert "Based on model architecture and training setup" not in html


### PR DESCRIPTION
## Summary

Simplifies the display of auto-selected `batch_size` and `learning_rate` values in the configuration report table.

## Changes

- Displays the resolved auto-selected value on its own line.
- Shows `Auto-selected by Ludwig` when no selection is made by the user.
- Adds tests for the updated batch size and learning rate output.

