### PR TITLE
manuscript release bioinformatics

### DIFF
--- a/MANUSCRIPT_RELEASE.md
+++ b/MANUSCRIPT_RELEASE.md
@@ -1,0 +1,19 @@
+# GLEAM Manuscript Release
+
+**GLEAM suite version:** `1.0.0`
+
+## Manuscript Components
+
+- **Tabular Learner:** `0.1.5`
+- **Image Learner:** `0.1.5`
+- **Multimodal Learner:** `0.1.9`
+
+## Containers
+
+- `quay.io/goeckslab/galaxy-pycaret:3.3.2`
+- `quay.io/goeckslab/galaxy-ludwig-gpu:0.10.1`
+- `quay.io/goeckslab/multimodal-learner:1.4.0`
+
+## Associated Manuscript
+
+**GLEAM: accessible, reproducible, and best-practice machine learning for biomedical research**


### PR DESCRIPTION
This PR adds a new Manuscript_release.md file that documents the exact GLEAM software versions associated with the manuscript analyses.

The purpose of this manifest is to make the manuscript’s computational state explicit and reproducible, rather than relying on whatever version of the repository happens to be on main at the time of submission or release.

What is included

The new file records:

GLEAM suite version: 1.0.0
Tabular Learner wrapper version: 0.1.5
Image Learner wrapper version: 0.1.5
Multimodal Learner wrapper version: 0.1.9
Exact container images used for the PyCaret-, Ludwig-, and AutoGluon-based analyses
The title of the associated GLEAM manuscript
Why this is needed

The manuscript Methods section reports specific wrapper and container versions used to generate the published results. This release manifest provides a single, unambiguous reference point linking those reported versions to the corresponding software release.

Before the manuscript release is archived, the associated Git commit should be verified to contain these exact versions. If the archived release uses different versions, the manuscript should be updated accordingly.