### PR TITLE
Fix/multiclass accuracy metric labels

### DIFF
--- a/tools/imagelearner/constants.py
+++ b/tools/imagelearner/constants.py
@@ -218,3 +218,16 @@ METRIC_DISPLAY_NAMES = {
     "mean_absolute_percentage_error": "Mean Absolute % Error",
     "root_mean_squared_percentage_error": "Root Mean Squared % Error",
 }
+# Ludwig 0.10.x quirk: for category (multi-class) outputs, the "accuracy" metric is
+# torchmetrics MulticlassAccuracy with its default average="macro", i.e. the
+# macro-average of per-class recall (balanced accuracy) — NOT sample-level accuracy.
+# "accuracy_micro" (average="micro") is the standard sample-level accuracy, which for
+# single-label multi-class equals micro precision/recall/F1. Ludwig's multi-class
+# "roc_auc" (MulticlassAUROC) is likewise macro-averaged. These overrides are applied
+# only for multi-class reports; binary "accuracy"/"roc_auc" are standard and keep
+# their base labels.
+MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES = {
+    "accuracy": "Balanced Accuracy (Macro Recall)",
+    "accuracy_micro": "Accuracy",
+    "roc_auc": "Macro ROC-AUC",
+}

--- a/tools/imagelearner/html_structure.py
+++ b/tools/imagelearner/html_structure.py
@@ -3,7 +3,11 @@ import json
 from html import escape
 from typing import Any, Dict, List, Optional
 
-from constants import DEFAULT_HITS_AT_K, METRIC_DISPLAY_NAMES
+from constants import (
+    DEFAULT_HITS_AT_K,
+    METRIC_DISPLAY_NAMES,
+    MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES,
+)
 from utils import detect_output_type, extract_metrics_from_json
 
 
@@ -16,10 +20,21 @@ def generate_table_row(cells, styles):
     )
 
 
-def format_metric_display_name(metric_key: str, top_k: int = DEFAULT_HITS_AT_K) -> str:
-    """Return a user-facing metric label with resolved parameters."""
+def format_metric_display_name(
+    metric_key: str,
+    top_k: int = DEFAULT_HITS_AT_K,
+    output_type: Optional[str] = None,
+) -> str:
+    """Return a user-facing metric label with resolved parameters.
+
+    For multi-class ("category") outputs, Ludwig's "accuracy" is macro-averaged
+    per-class recall (balanced accuracy) and "accuracy_micro" is the standard
+    sample-level accuracy, so their labels are overridden accordingly.
+    """
     if metric_key == "hits_at_k":
         return f"Hits@{int(top_k)}"
+    if output_type == "category" and metric_key in MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES:
+        return MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES[metric_key]
     return METRIC_DISPLAY_NAMES.get(metric_key, metric_key.replace("_", " ").title())
 
 
@@ -691,13 +706,14 @@ def get_metrics_help_modal() -> str:
         '      <h3>3) Classification Metrics</h3>'
         '      <p><strong>Accuracy:</strong> Proportion of correct predictions '
         'among all predictions. Simple but misleading for imbalanced datasets, '
-        'where high accuracy may hide poor performance on minority classes.</p>'
-        '      <p><strong>Micro Accuracy:</strong> Sums true positives and true negatives '
-        'across all classes before computing accuracy. Suitable for multiclass or '
-        'multilabel problems with imbalanced data.</p>'
-        '      <p><strong>Token Accuracy:</strong> Measures how often predicted tokens '
-        '(e.g., in sequences) match true tokens. Common in NLP tasks like text generation '
-        'or token classification.</p>'
+        'where high accuracy may hide poor performance on minority classes. '
+        'For single-label multi-class problems it is identical to micro-averaged '
+        'precision, recall, and F1.</p>'
+        '      <p><strong>Balanced Accuracy (Macro Recall):</strong> The unweighted '
+        'mean of per-class recall, treating every class equally regardless of size. '
+        'Lower than accuracy when minority classes are predicted less reliably. '
+        'In multi-class reports this replaces the raw Ludwig "accuracy" metric, '
+        'which is macro-averaged.</p>'
         '      <p><strong>Precision:</strong> Proportion of positive predictions that are '
         'correct (TP / (TP + FP)). Use when false positives are costly, e.g., spam detection.</p>'
         '      <p><strong>Recall (Sensitivity):</strong> Proportion of actual positives '
@@ -908,7 +924,7 @@ def format_stats_table_html(
             metric_key in all_metrics["validation"]
             and metric_key in all_metrics["test"]
         ):
-            display_name = format_metric_display_name(metric_key, top_k)
+            display_name = format_metric_display_name(metric_key, top_k, output_type)
             t = all_metrics["training"].get(metric_key)
             v = all_metrics["validation"].get(metric_key)
             te = all_metrics["test"].get(metric_key)
@@ -955,11 +971,12 @@ def format_train_val_stats_table_html(
     top_k: int = DEFAULT_HITS_AT_K,
 ) -> str:
     """Format train/validation metrics into an HTML table."""
-    all_metrics = extract_metrics_from_json(train_stats, test_stats, detect_output_type(test_stats))
+    output_type = detect_output_type(test_stats)
+    all_metrics = extract_metrics_from_json(train_stats, test_stats, output_type)
     rows = []
     for metric_key in sorted(all_metrics["training"].keys()):
         if metric_key in all_metrics["validation"]:
-            display_name = format_metric_display_name(metric_key, top_k)
+            display_name = format_metric_display_name(metric_key, top_k, output_type)
             t = all_metrics["training"].get(metric_key)
             v = all_metrics["validation"].get(metric_key)
             if t is not None and v is not None:
@@ -1005,7 +1022,7 @@ def format_test_merged_stats_table_html(
     """Format test metrics into an HTML table."""
     rows = []
     for key in sorted(test_metrics.keys()):
-        display_name = format_metric_display_name(key, top_k)
+        display_name = format_metric_display_name(key, top_k, output_type)
         value = test_metrics[key]
         if value is not None:
             rows.append([display_name, f"{value:.4f}"])

--- a/tools/imagelearner/utils.py
+++ b/tools/imagelearner/utils.py
@@ -146,6 +146,17 @@ def extract_metrics_from_json(
             exclude = {"per_class_stats", "precision_recall_curve", "roc_curve"}
         else:
             exclude = {"per_class_stats", "confusion_matrix"}
+            # Ludwig 0.10.1 bug (ludwig/utils/eval_utils.py::ConfusionMatrix.stats):
+            # "avg_precision_weighted" and "avg_recall_weighted" are computed with
+            # average="micro", so they silently duplicate the micro values instead of
+            # being support-weighted. "token_accuracy" (sklearn accuracy_score) is an
+            # exact duplicate of accuracy_micro under a name that is meaningless for
+            # image classification. Drop all three from the report.
+            exclude |= {
+                "avg_precision_weighted",
+                "avg_recall_weighted",
+                "token_accuracy",
+            }
 
         # 1. Get all scalar test_label_stats not excluded
         test_metrics = {}
@@ -157,8 +168,10 @@ def extract_metrics_from_json(
             if isinstance(v, (int, float, str, bool)):
                 test_metrics[k] = v
 
-        # 2. Add overall_stats (flattened)
+        # 2. Add overall_stats (flattened), applying the same exclusions
         for k, v in overall_stats.items():
+            if k in exclude:
+                continue
             test_metrics[k] = v
 
         # 3. Optionally include combined/loss if present and not already


### PR DESCRIPTION
## Fix mislabeled multiclass metrics in the Image Learner report

### Problem

For multiclass models, the report's "Accuracy" and "Micro F1-score" disagreed (e.g. 0.8044 vs 0.8947 on HAM10000), which is impossible for single-label multiclass classification, where micro-F1 ≡ accuracy.

An audit traced this to Ludwig 0.10.1, whose stats the tool relabels verbatim:

- **`accuracy` is not accuracy.** Ludwig's `CategoryAccuracy` subclasses torchmetrics `MulticlassAccuracy` without an `average` argument, inheriting the default `average="macro"`. The reported value is therefore macro-averaged per-class recall (balanced accuracy). Confirmed empirically: "Accuracy" always equals the "Macro Recall" row to 4 decimals.
- **`accuracy_micro` is the true sample-level accuracy** (`average="micro"`), identical to micro precision/recall/F1 and `token_accuracy`.
- **`avg_precision_weighted` / `avg_recall_weighted` are miscomputed upstream.** Ludwig's `ConfusionMatrix.stats()` (`ludwig/utils/eval_utils.py`) passes `average="micro"` for both, so these rows silently duplicated the micro values instead of being support-weighted.
- Multiclass `roc_auc` (`MulticlassAUROC`) is macro-averaged but was labeled plain "ROC-AUC".

### Changes

- `constants.py`: add `MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES` — for category outputs, `accuracy` → "Balanced Accuracy (Macro Recall)", `accuracy_micro` → "Accuracy", `roc_auc` → "Macro ROC-AUC".
- `html_structure.py`: `format_metric_display_name()` accepts `output_type` and applies the overrides only for multiclass; threaded through all three summary tables. Help modal updated (Balanced Accuracy entry added, obsolete Token Accuracy entry removed).
- `utils.py`: for multiclass test stats, exclude `avg_precision_weighted` and `avg_recall_weighted` (wrong values, per the Ludwig bug above) and `token_accuracy` (exact duplicate of accuracy); exclusions now also apply to the flattened `overall_stats`.

**No metric values are recomputed** — only labels and row selection change. Binary and regression reports are untouched.