### PR TITLE
Fix mislabeled multiclass metrics in image learner report

### DIFF
--- a/tools/imagelearner/constants.py
+++ b/tools/imagelearner/constants.py
@@ -218,3 +218,16 @@ METRIC_DISPLAY_NAMES = {
     "mean_absolute_percentage_error": "Mean Absolute % Error",
     "root_mean_squared_percentage_error": "Root Mean Squared % Error",
 }
+# Ludwig 0.10.x quirk: for category (multi-class) outputs, the "accuracy" metric is
+# torchmetrics MulticlassAccuracy with its default average="macro", i.e. the
+# macro-average of per-class recall (balanced accuracy) — NOT sample-level accuracy.
+# "accuracy_micro" (average="micro") is the standard sample-level accuracy, which for
+# single-label multi-class equals micro precision/recall/F1. Ludwig's multi-class
+# "roc_auc" (MulticlassAUROC) is likewise macro-averaged. These overrides are applied
+# only for multi-class reports; binary "accuracy"/"roc_auc" are standard and keep
+# their base labels.
+MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES = {
+    "accuracy": "Balanced Accuracy (Macro Recall)",
+    "accuracy_micro": "Accuracy",
+    "roc_auc": "Macro ROC-AUC",
+}

--- a/tools/imagelearner/html_structure.py
+++ b/tools/imagelearner/html_structure.py
@@ -188,7 +188,9 @@ def format_config_table_html(
             elif key == "validation_metric":
                 if val is not None:
                     val_str = format_metric_display_name(
-                        str(val), int(config.get("top_k") or DEFAULT_HITS_AT_K)
+                        str(val),
+                        int(config.get("top_k") or DEFAULT_HITS_AT_K),
+                        output_type,
                     )
                 else:
                     val_str = "N/A"

--- a/tools/imagelearner/html_structure.py
+++ b/tools/imagelearner/html_structure.py
@@ -3,7 +3,11 @@ import json
 from html import escape
 from typing import Any, Dict, List, Optional
 
-from constants import DEFAULT_HITS_AT_K, METRIC_DISPLAY_NAMES
+from constants import (
+    DEFAULT_HITS_AT_K,
+    METRIC_DISPLAY_NAMES,
+    MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES,
+)
 from utils import detect_output_type, extract_metrics_from_json
 
 
@@ -16,10 +20,21 @@ def generate_table_row(cells, styles):
     )
 
 
-def format_metric_display_name(metric_key: str, top_k: int = DEFAULT_HITS_AT_K) -> str:
-    """Return a user-facing metric label with resolved parameters."""
+def format_metric_display_name(
+    metric_key: str,
+    top_k: int = DEFAULT_HITS_AT_K,
+    output_type: Optional[str] = None,
+) -> str:
+    """Return a user-facing metric label with resolved parameters.
+
+    For multi-class ("category") outputs, Ludwig's "accuracy" is macro-averaged
+    per-class recall (balanced accuracy) and "accuracy_micro" is the standard
+    sample-level accuracy, so their labels are overridden accordingly.
+    """
     if metric_key == "hits_at_k":
         return f"Hits@{int(top_k)}"
+    if output_type == "category" and metric_key in MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES:
+        return MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES[metric_key]
     return METRIC_DISPLAY_NAMES.get(metric_key, metric_key.replace("_", " ").title())
 
 
@@ -691,13 +706,14 @@ def get_metrics_help_modal() -> str:
         '      <h3>3) Classification Metrics</h3>'
         '      <p><strong>Accuracy:</strong> Proportion of correct predictions '
         'among all predictions. Simple but misleading for imbalanced datasets, '
-        'where high accuracy may hide poor performance on minority classes.</p>'
-        '      <p><strong>Micro Accuracy:</strong> Sums true positives and true negatives '
-        'across all classes before computing accuracy. Suitable for multiclass or '
-        'multilabel problems with imbalanced data.</p>'
-        '      <p><strong>Token Accuracy:</strong> Measures how often predicted tokens '
-        '(e.g., in sequences) match true tokens. Common in NLP tasks like text generation '
-        'or token classification.</p>'
+        'where high accuracy may hide poor performance on minority classes. '
+        'For single-label multi-class problems it is identical to micro-averaged '
+        'precision, recall, and F1.</p>'
+        '      <p><strong>Balanced Accuracy (Macro Recall):</strong> The unweighted '
+        'mean of per-class recall, treating every class equally regardless of size. '
+        'Lower than accuracy when minority classes are predicted less reliably. '
+        'In multi-class reports this replaces the raw Ludwig "accuracy" metric, '
+        'which is macro-averaged.</p>'
         '      <p><strong>Precision:</strong> Proportion of positive predictions that are '
         'correct (TP / (TP + FP)). Use when false positives are costly, e.g., spam detection.</p>'
         '      <p><strong>Recall (Sensitivity):</strong> Proportion of actual positives '
@@ -908,7 +924,7 @@ def format_stats_table_html(
             metric_key in all_metrics["validation"]
             and metric_key in all_metrics["test"]
         ):
-            display_name = format_metric_display_name(metric_key, top_k)
+            display_name = format_metric_display_name(metric_key, top_k, output_type)
             t = all_metrics["training"].get(metric_key)
             v = all_metrics["validation"].get(metric_key)
             te = all_metrics["test"].get(metric_key)
@@ -955,11 +971,12 @@ def format_train_val_stats_table_html(
     top_k: int = DEFAULT_HITS_AT_K,
 ) -> str:
     """Format train/validation metrics into an HTML table."""
-    all_metrics = extract_metrics_from_json(train_stats, test_stats, detect_output_type(test_stats))
+    output_type = detect_output_type(test_stats)
+    all_metrics = extract_metrics_from_json(train_stats, test_stats, output_type)
     rows = []
     for metric_key in sorted(all_metrics["training"].keys()):
         if metric_key in all_metrics["validation"]:
-            display_name = format_metric_display_name(metric_key, top_k)
+            display_name = format_metric_display_name(metric_key, top_k, output_type)
             t = all_metrics["training"].get(metric_key)
             v = all_metrics["validation"].get(metric_key)
             if t is not None and v is not None:
@@ -1005,7 +1022,7 @@ def format_test_merged_stats_table_html(
     """Format test metrics into an HTML table."""
     rows = []
     for key in sorted(test_metrics.keys()):
-        display_name = format_metric_display_name(key, top_k)
+        display_name = format_metric_display_name(key, top_k, output_type)
         value = test_metrics[key]
         if value is not None:
             rows.append([display_name, f"{value:.4f}"])

--- a/tools/imagelearner/ludwig_backend.py
+++ b/tools/imagelearner/ludwig_backend.py
@@ -2253,7 +2253,9 @@ class LudwigDirectBackend:
                     tab2_content = append_plot_blocks(tab2_content, tv_plots)
                 else:
                     tv_plots = build_train_validation_plots(
-                        str(train_stats_path), top_k=hits_top_k
+                        str(train_stats_path),
+                        top_k=hits_top_k,
+                        output_type=output_type,
                     )
                     # Add threshold plot first, then other train/val plots
                     if threshold_plot:

--- a/tools/imagelearner/plotly_plots.py
+++ b/tools/imagelearner/plotly_plots.py
@@ -7,7 +7,12 @@ import pandas as pd
 import plotly.graph_objects as go
 import plotly.io as pio
 from calibration_plot import expected_calibration_error
-from constants import DEFAULT_HITS_AT_K, LABEL_COLUMN_NAME, SPLIT_COLUMN_NAME
+from constants import (
+    DEFAULT_HITS_AT_K,
+    LABEL_COLUMN_NAME,
+    MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES,
+    SPLIT_COLUMN_NAME,
+)
 from sklearn.calibration import calibration_curve
 from sklearn.metrics import (
     accuracy_score,
@@ -436,9 +441,16 @@ def build_classification_plots(
 
 
 def build_train_validation_plots(
-    train_stats_path: str, top_k: int = DEFAULT_HITS_AT_K
+    train_stats_path: str,
+    top_k: int = DEFAULT_HITS_AT_K,
+    output_type: Optional[str] = None,
 ) -> List[Dict[str, str]]:
-    """Generate Train/Validation learning curve plots from training_statistics.json."""
+    """Generate Train/Validation learning curve plots from training_statistics.json.
+
+    For multi-class ("category") runs, Ludwig's "accuracy" is macro-averaged
+    per-class recall and "roc_auc" is macro-averaged, so the curve titles are
+    relabeled to match the performance summary tables.
+    """
     if not train_stats_path or not Path(train_stats_path).exists():
         return []
     try:
@@ -464,15 +476,30 @@ def build_train_validation_plots(
         except Exception:
             return []
 
+    def _label(metric_key: str, default: str) -> str:
+        """Use the category-aware metric name so curves match the summary tables."""
+        if output_type == "category":
+            return MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES.get(metric_key, default)
+        return default
+
+    accuracy_label = _label("accuracy", "Accuracy")
+    accuracy_micro_label = _label("accuracy_micro", "Micro Accuracy")
+    roc_auc_label = _label("roc_auc", "ROC-AUC")
+
     metric_specs = [
         ("loss", "Loss across epochs", "Loss"),
-        ("accuracy", "Accuracy across epochs", "Accuracy"),
+        ("accuracy", f"{accuracy_label} across epochs", accuracy_label),
+        (
+            "accuracy_micro",
+            f"{accuracy_micro_label} across epochs",
+            accuracy_micro_label,
+        ),
         (
             "hits_at_k",
             f"Hits@{int(top_k)} across epochs (correct class in top {int(top_k)})",
             f"Hits@{int(top_k)}",
         ),
-        ("roc_auc", "ROC-AUC across epochs", "ROC-AUC"),
+        ("roc_auc", f"{roc_auc_label} across epochs", roc_auc_label),
         ("precision", "Precision across epochs", "Precision"),
         ("recall", "Recall/Sensitivity across epochs", "Recall"),
         ("specificity", "Specificity across epochs", "Specificity"),
@@ -530,12 +557,13 @@ def build_train_validation_plots(
     if roc_train and roc_val:
         max_len = min(len(roc_train), len(roc_val))
         gaps = [t - v for t, v in zip(roc_train[:max_len], roc_val[:max_len])]
+        gap_title = f"Overfitting gap: {roc_auc_label} across epochs"
         fig_gap = _line_chart(
-            [("Train - Val ROC-AUC", gaps)],
-            title="Overfitting gap: ROC-AUC across epochs",
+            [(f"Train - Val {roc_auc_label}", gaps)],
+            title=gap_title,
             yaxis_title="Gap",
         )
-        plots.append(_wrap_plot("Overfitting gap: ROC-AUC across epochs", fig_gap, include_js=include_js))
+        plots.append(_wrap_plot(gap_title, fig_gap, include_js=include_js))
         include_js = False
 
     # Best Epoch Dashboard (based on max val ROC-AUC)

--- a/tools/imagelearner/test_image_workflow.py
+++ b/tools/imagelearner/test_image_workflow.py
@@ -169,6 +169,50 @@ def test_metric_summary_formats_hits_at_3_without_changing_metric_values():
     assert "1.1000" in html
 
 
+def test_config_table_validation_metric_label_matches_multiclass_tables():
+    """Config table must use the same category-aware labels as the metric tables.
+
+    Ludwig's multiclass "accuracy" is macro-averaged per-class recall, so a run
+    validated on it has to read "Balanced Accuracy (Macro Recall)" in the config
+    table too - otherwise it contradicts the performance summaries.
+    """
+    html_structure = importlib.import_module("html_structure")
+
+    multiclass_html = html_structure.format_config_table_html(
+        {"validation_metric": "accuracy"}, output_type="category"
+    )
+    value_html = _config_table_value_html(multiclass_html, "Validation Metric")
+    assert value_html == "Balanced Accuracy (Macro Recall)"
+
+    # The label must agree with the one used in the performance tables.
+    assert value_html == html_structure.format_metric_display_name(
+        "accuracy", output_type="category"
+    )
+
+    # accuracy_micro is the true sample-level accuracy for multiclass.
+    micro_html = html_structure.format_config_table_html(
+        {"validation_metric": "accuracy_micro"}, output_type="category"
+    )
+    assert _config_table_value_html(micro_html, "Validation Metric") == "Accuracy"
+
+    # Binary and unknown output types keep the original labels.
+    binary_html = html_structure.format_config_table_html(
+        {"validation_metric": "accuracy"}, output_type="binary"
+    )
+    assert _config_table_value_html(binary_html, "Validation Metric") == "Accuracy"
+
+    default_html = html_structure.format_config_table_html(
+        {"validation_metric": "accuracy"}
+    )
+    assert _config_table_value_html(default_html, "Validation Metric") == "Accuracy"
+
+    # top_k resolution still works alongside the new argument.
+    hits_html = html_structure.format_config_table_html(
+        {"validation_metric": "hits_at_k", "top_k": 5}, output_type="category"
+    )
+    assert _config_table_value_html(hits_html, "Validation Metric") == "Hits@5"
+
+
 def test_config_table_shows_model_compatible_image_size_when_adapted():
     html_structure = importlib.import_module("html_structure")
 

--- a/tools/imagelearner/test_plotly_plots.py
+++ b/tools/imagelearner/test_plotly_plots.py
@@ -36,6 +36,63 @@ def test_train_validation_plots_include_hits_at_3_when_available(tmp_path):
     assert "Hits@3 across epochs (correct class in top 3)" in titles
 
 
+def _write_multiclass_training_stats(tmp_path):
+    stats_path = tmp_path / "training_statistics.json"
+    stats_path.write_text(
+        """
+{
+  "training": {"label": {"accuracy": [0.8, 0.98], "accuracy_micro": [0.82, 0.98],
+                         "roc_auc": [0.95, 0.99], "loss": [1.2, 0.05]}},
+  "validation": {"label": {"accuracy": [0.7, 0.87], "accuracy_micro": [0.72, 0.87],
+                           "roc_auc": [0.93, 0.98], "loss": [1.4, 0.33]}}
+}
+"""
+    )
+    return stats_path
+
+
+def test_train_validation_plot_titles_use_multiclass_metric_labels(tmp_path):
+    """Curve titles must match the performance tables for category runs.
+
+    Ludwig's multiclass "accuracy" is macro-averaged per-class recall and its
+    "roc_auc" is macro-averaged, so plotting them as plain "Accuracy"/"ROC-AUC"
+    contradicts the summary tables.
+    """
+    stats_path = _write_multiclass_training_stats(tmp_path)
+
+    titles = [
+        plot["title"]
+        for plot in build_train_validation_plots(
+            str(stats_path), top_k=3, output_type="category"
+        )
+    ]
+
+    assert "Balanced Accuracy (Macro Recall) across epochs" in titles
+    assert "Accuracy across epochs" in titles  # from accuracy_micro
+    assert "Macro ROC-AUC across epochs" in titles
+    assert "Overfitting gap: Macro ROC-AUC across epochs" in titles
+    assert "Micro Accuracy across epochs" not in titles
+    assert "ROC-AUC across epochs" not in titles
+    assert "Overfitting gap: ROC-AUC across epochs" not in titles
+
+
+def test_train_validation_plot_titles_unchanged_for_binary_and_default(tmp_path):
+    stats_path = _write_multiclass_training_stats(tmp_path)
+
+    for output_type in ("binary", None):
+        titles = [
+            plot["title"]
+            for plot in build_train_validation_plots(
+                str(stats_path), top_k=3, output_type=output_type
+            )
+        ]
+        assert "Accuracy across epochs" in titles
+        assert "ROC-AUC across epochs" in titles
+        assert "Overfitting gap: ROC-AUC across epochs" in titles
+        assert "Balanced Accuracy (Macro Recall) across epochs" not in titles
+        assert "Macro ROC-AUC across epochs" not in titles
+
+
 def test_optimize_binary_threshold_uses_requested_metric():
     result = optimize_binary_threshold_values(
         np.array([0, 1, 1, 0]),

--- a/tools/imagelearner/utils.py
+++ b/tools/imagelearner/utils.py
@@ -146,6 +146,17 @@ def extract_metrics_from_json(
             exclude = {"per_class_stats", "precision_recall_curve", "roc_curve"}
         else:
             exclude = {"per_class_stats", "confusion_matrix"}
+            # Ludwig 0.10.1 bug (ludwig/utils/eval_utils.py::ConfusionMatrix.stats):
+            # "avg_precision_weighted" and "avg_recall_weighted" are computed with
+            # average="micro", so they silently duplicate the micro values instead of
+            # being support-weighted. "token_accuracy" (sklearn accuracy_score) is an
+            # exact duplicate of accuracy_micro under a name that is meaningless for
+            # image classification. Drop all three from the report.
+            exclude |= {
+                "avg_precision_weighted",
+                "avg_recall_weighted",
+                "token_accuracy",
+            }
 
         # 1. Get all scalar test_label_stats not excluded
         test_metrics = {}
@@ -157,8 +168,10 @@ def extract_metrics_from_json(
             if isinstance(v, (int, float, str, bool)):
                 test_metrics[k] = v
 
-        # 2. Add overall_stats (flattened)
+        # 2. Add overall_stats (flattened), applying the same exclusions
         for k, v in overall_stats.items():
+            if k in exclude:
+                continue
             test_metrics[k] = v
 
         # 3. Optionally include combined/loss if present and not already


### PR DESCRIPTION
## Fix mislabeled multiclass metrics in the Image Learner report

### Problem

For multiclass models, the report's "Accuracy" and "Micro F1-score" disagreed (e.g. 0.8044 vs 0.8947 on HAM10000), which is impossible for single-label multiclass classification, where micro-F1 ≡ accuracy.

An audit traced this to Ludwig 0.10.1, whose stats the tool relabels verbatim:

- **`accuracy` is not accuracy.** Ludwig's `CategoryAccuracy` subclasses torchmetrics `MulticlassAccuracy` without an `average` argument, inheriting the default `average="macro"`. The reported value is therefore macro-averaged per-class recall (balanced accuracy). Confirmed empirically: "Accuracy" always equals the "Macro Recall" row to 4 decimals.
- **`accuracy_micro` is the true sample-level accuracy** (`average="micro"`), identical to micro precision/recall/F1 and `token_accuracy`.
- **`avg_precision_weighted` / `avg_recall_weighted` are miscomputed upstream.** Ludwig's `ConfusionMatrix.stats()` (`ludwig/utils/eval_utils.py`) passes `average="micro"` for both, so these rows silently duplicated the micro values instead of being support-weighted.
- Multiclass `roc_auc` (`MulticlassAUROC`) is macro-averaged but was labeled plain "ROC-AUC".

### Changes

- `constants.py`: add `MULTICLASS_METRIC_DISPLAY_NAME_OVERRIDES` — for category outputs, `accuracy` → "Balanced Accuracy (Macro Recall)", `accuracy_micro` → "Accuracy", `roc_auc` → "Macro ROC-AUC".
- `html_structure.py`: `format_metric_display_name()` accepts `output_type` and applies the overrides only for multiclass; threaded through all three summary tables. Help modal updated (Balanced Accuracy entry added, obsolete Token Accuracy entry removed).
- `utils.py`: for multiclass test stats, exclude `avg_precision_weighted` and `avg_recall_weighted` (wrong values, per the Ludwig bug above) and `token_accuracy` (exact duplicate of accuracy); exclusions now also apply to the flattened `overall_stats`.

**No metric values are recomputed** — only labels and row selection change. Binary and regression reports are untouched.