### PR TITLE
Ship calibration_plot.py in the Galaxy tool bundle

### DIFF
--- a/tools/imagelearner/image_learner.xml
+++ b/tools/imagelearner/image_learner.xml
@@ -4,6 +4,7 @@
         <container type="docker">quay.io/goeckslab/galaxy-ludwig-gpu:0.10.1</container>
     </requirements>
     <required_files>
+        <include path="calibration_plot.py" />
         <include path="constants.py" />
         <include path="html_structure.py" />
         <include path="image_learner_cli.py" />

--- a/tools/multimodallearner/multimodal_learner.xml
+++ b/tools/multimodallearner/multimodal_learner.xml
@@ -7,6 +7,7 @@
 
   <required_files>
     <include path="multimodal_learner.py"/>
+    <include path="calibration_plot.py"/>
     <include path="utils.py"/>
     <include path="split_logic.py"/>
     <include path="training_pipeline.py"/>

--- a/tools/tabularlearner/tabular_learner.xml
+++ b/tools/tabularlearner/tabular_learner.xml
@@ -6,6 +6,7 @@
     <expand macro="python_requirements" />
     <required_files>
         <include path="base_model_trainer.py" />
+        <include path="calibration_plot.py" />
         <include path="classification_metrics.py" />
         <include path="dashboard.py" />
         <include path="explainability_limits.py" />


### PR DESCRIPTION
Updating the <required_files> to fix the following problem on usegalaxy.org:
`            Traceback (most recent call last):
  File "/jetstream2/scratch/main/jobs/78675941/tool_files/image_learner_cli.py", line 9, in <module>
    from image_workflow import ImageLearnerCLI
  File "/jetstream2/scratch/main/jobs/78675941/tool_files/image_workflow.py", line 23, in <module>
    from ludwig_backend import Backend
  File "/jetstream2/scratch/main/jobs/78675941/tool_files/ludwig_backend.py", line 42, in <module>
    from plotly_plots import (
  File "/jetstream2/scratch/main/jobs/78675941/tool_files/plotly_plots.py", line 9, in <module>
    from calibration_plot import expected_calibration_error
ModuleNotFoundError: No module named 'calibration_plot'`